### PR TITLE
Fix weird "April 15,2015" date formatting

### DIFF
--- a/php/pantheon/checks/cron.php
+++ b/php/pantheon/checks/cron.php
@@ -85,7 +85,7 @@ class Cron extends Checkimplementation {
         	      $class = "error";
       	        $this->action = "<div class='warning'>Some cronjobs are outdated.</div>";
           	  }
-            	$rows[] = array('class'=>$class,'data'=> array('jobname' => $job,'schedule' => $data['schedule'], 'next' => date('M j,Y @ H:i:s', $timestamp)));    
+            	$rows[] = array('class'=>$class,'data'=> array('jobname' => $job,'schedule' => $data['schedule'], 'next' => date('M j, Y @ H:i:s', $timestamp)));    
           	}
         	}
 				}


### PR DESCRIPTION
Adds a space before the date, so it’s not all squished together.