### PR TITLE
Truncate cron output to prevent oversized reports

### DIFF
--- a/php/pantheon/checks/cron.php
+++ b/php/pantheon/checks/cron.php
@@ -78,6 +78,11 @@ class Cron extends Checkimplementation {
         // @TODO move this logic to the run() function or checkCron() function
 				if ($this->cron) {
         	foreach ($this->cron as $timestamp => $crons) { 
+            // Truncate the crons list so we're not creating unreasonably large reports
+            // @TODO: A lot of cron jobs may be a sign of trouble and should probably be a warning.
+            if (count($crons) < 100) {
+              $crons = array_slice($crons, 0, 100, true);
+            }
           	foreach ($crons as $job => $data) {
 	            $class = 'ok';
   	          $data = array_shift($data);

--- a/php/pantheon/checks/cron.php
+++ b/php/pantheon/checks/cron.php
@@ -78,8 +78,9 @@ class Cron extends Checkimplementation {
         // @TODO move this logic to the run() function or checkCron() function
 				if ($this->cron) {
         	foreach ($this->cron as $timestamp => $crons) { 
-            // Truncate the crons list so we're not creating unreasonably large reports
-            // @TODO: A lot of cron jobs may be a sign of trouble and should probably be a warning.
+            // Truncate the crons list so we're not creating unreasonably large reports caused by:
+            // https://core.trac.wordpress.org/ticket/33423
+            // @TODO: Turn this into a warning with a suggestion to patch or upgrade.
             if (count($crons) < 100) {
               $crons = array_slice($crons, 0, 100, true);
             }


### PR DESCRIPTION
In some circumstances the output can be excessively large when reporting all cron jobs. This quick fix limits the number of reported jobs to 100 per task.