### PR TITLE
Add missing space in cron check date format

### DIFF
--- a/php/pantheon/checks/cron.php
+++ b/php/pantheon/checks/cron.php
@@ -69,7 +69,7 @@ class Cron extends Checkimplementation {
         else if ($timestamp < $now) {
           $past++;
           $class = "error";
-          $next = date('M j,Y @ H:i:s', $timestamp) . ' (PAST DUE)';
+          $next = date('M j, Y @ H:i:s', $timestamp) . ' (PAST DUE)';
         }
         $this->cron_rows[] = array('class' => $class, 'data' => array('jobname' => $job, 'schedule' => $data['schedule'], 'next' => $next));
         $total++;


### PR DESCRIPTION
"April 15, 2015" instead of "April 15,2015"

Previously #22