### PR TITLE
Fix undefined variable notice

### DIFF
--- a/php/pantheon/checker.php
+++ b/php/pantheon/checker.php
@@ -29,7 +29,7 @@ class Checker {
     }
 
     foreach($this->callbacks as $class => $object) {
-      $object->run($file);
+      $object->run();
     }
 
     foreach($this->callbacks as $class => $object) {


### PR DESCRIPTION
```
salty-wordpress ➜  pantheon.dev  wp launchcheck config
PHP Notice:  Undefined variable: file in
/srv/www/pantheon.dev/wp_launch_check/php/pantheon/checker.php on line
32
```

Introduced in
https://github.com/pantheon-systems/wp_launch_check/commit/e0094cd3ed147ca5d21533f5a701a254530aaca3#diff-1d439fcb6dbf9cc41033aa0f5b226a71R32