### PR TITLE
Check DB constants are set by `$_ENV` when applicable

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -210,3 +210,9 @@ Feature: Check the wp-config.php file
 			"""
 			Error: Error establishing a database connection
 			"""
+
+		When I try `wp --require=wp-config-env.php launchcheck all`
+		Then STDERR should be:
+			"""
+			Error: Error establishing a database connection
+			"""

--- a/features/config.feature
+++ b/features/config.feature
@@ -220,7 +220,19 @@ Feature: Check the wp-config.php file
 			"""
 
 		When I try `wp --require=wp-config-env.php launchcheck all`
-		Then STDERR should be:
+		Then STDOUT should contain:
+			"""
+			Some database constants differ from their expected $_ENV values: DB_USER, DB_PASSWORD
+			"""
+		And STDOUT should contain:
+			"""
+			Recommendation: Please <a href="https://pantheon.io/docs/wp-config-php/">update your wp-config.php</a> file to support $_ENV-based configuration values.
+			"""
+		And STDERR should contain:
+			"""
+			Warning: Detected invalid database credentials, skipping remaining checks
+			"""
+		And STDERR should not contain:
 			"""
 			Error: Error establishing a database connection
 			"""

--- a/features/config.feature
+++ b/features/config.feature
@@ -164,6 +164,10 @@ Feature: Check the wp-config.php file
 			"""
 			DB_NAME, DB_USER, DB_PASSWORD, DB_HOST are set to their expected $_ENV values.
 			"""
+		And STDOUT should contain:
+			"""
+			Recommendation: No action required
+			"""
 
 		Given a wp-config.php file:
 			"""
@@ -203,6 +207,10 @@ Feature: Check the wp-config.php file
 		Then STDOUT should contain:
 			"""
 			Some database constants differ from their expected $_ENV values: DB_USER, DB_PASSWORD
+			"""
+		And STDOUT should contain:
+			"""
+			Recommendation: Please <a href="https://pantheon.io/docs/wp-config-php/">update your wp-config.php</a> file to support $_ENV-based configuration values.
 			"""
 
 		When I try `wp --require=wp-config-env.php launchcheck cron`

--- a/features/config.feature
+++ b/features/config.feature
@@ -112,3 +112,101 @@ Feature: Check the wp-config.php file
 			"""
 			Verified that $_SERVER['SERVER_NAME'] isn't being used to define WP_HOME or WP_SITE_URL
 			"""
+
+	Scenario: Check that $_ENV variables are used to populate database credentials
+		Given a WP install
+		And a wp-config.php file:
+			"""
+			<?php
+			// ** MySQL settings ** //
+			/** The name of the database for WordPress */
+			define('DB_NAME', $_ENV['DB_NAME'] );
+
+			/** MySQL database username */
+			define('DB_USER', $_ENV['DB_USER'] );
+
+			/** MySQL database password */
+			define('DB_PASSWORD', $_ENV['DB_PASSWORD'] );
+
+			/** MySQL hostname */
+			define('DB_HOST', $_ENV['DB_HOST'] . ':' . $_ENV['DB_PORT'] );
+
+			/** Database Charset to use in creating database tables. */
+			define('DB_CHARSET', 'utf8');
+
+			/** The Database Collate type. Don't change this if in doubt. */
+			define('DB_COLLATE', '');
+
+			$table_prefix = 'wp_';
+
+			/* That's all, stop editing! Happy blogging. */
+
+			/** Absolute path to the WordPress directory. */
+			if ( !defined('ABSPATH') )
+				define('ABSPATH', dirname(__FILE__) . '/');
+
+			/** Sets up WordPress vars and included files. */
+			require_once(ABSPATH . 'wp-settings.php');
+			"""
+		And a wp-config-env.php file:
+			"""
+			<?php
+			$_ENV['PANTHEON_ENVIRONMENT'] = 'dev';
+			$_ENV['DB_NAME'] = 'wp_cli_test';
+			$_ENV['DB_USER'] = 'wp_cli_test';
+			$_ENV['DB_PASSWORD'] = 'password1';
+			$_ENV['DB_HOST'] = '127.0.0.1';
+			$_ENV['DB_PORT'] = '3306';
+			"""
+
+		When I run `wp --require=wp-config-env.php launchcheck config`
+		Then STDOUT should contain:
+			"""
+			DB_NAME, DB_USER, DB_PASSWORD, DB_HOST are set to their expected $_ENV values.
+			"""
+
+		Given a wp-config.php file:
+			"""
+			<?php
+			// ** MySQL settings ** //
+			/** The name of the database for WordPress */
+			define('DB_NAME', $_ENV['DB_NAME'] );
+
+			/** MySQL database username */
+			define('DB_USER', 'baduser' );
+
+			/** MySQL database password */
+			define('DB_PASSWORD', 'badpassword' );
+
+			/** MySQL hostname */
+			define('DB_HOST', $_ENV['DB_HOST'] . ':' . $_ENV['DB_PORT'] );
+
+			/** Database Charset to use in creating database tables. */
+			define('DB_CHARSET', 'utf8');
+
+			/** The Database Collate type. Don't change this if in doubt. */
+			define('DB_COLLATE', '');
+
+			$table_prefix = 'wp_';
+
+			/* That's all, stop editing! Happy blogging. */
+
+			/** Absolute path to the WordPress directory. */
+			if ( !defined('ABSPATH') )
+				define('ABSPATH', dirname(__FILE__) . '/');
+
+			/** Sets up WordPress vars and included files. */
+			require_once(ABSPATH . 'wp-settings.php');
+			"""
+
+		When I run `wp --require=wp-config-env.php launchcheck config`
+		Then STDOUT should contain:
+			"""
+			Some database constants differ from their expected $_ENV values: DB_USER, DB_PASSWORD
+			"""
+
+		When I try `wp --require=wp-config-env.php launchcheck cron`
+		Then STDERR should be:
+			"""
+			Error: Error establishing a database connection
+			"""

--- a/php/commands/launchcheck.php
+++ b/php/commands/launchcheck.php
@@ -21,6 +21,10 @@ class LaunchCheck {
 		$checker->register( new \Pantheon\Checks\Config() );
 		$checker->execute();
 
+		// Config only loads WP with valid db credentials. If they're invalid,
+		// Then this will trigger a database connection error.
+		@WP_CLI::get_runner()->load_wordpress();
+
 		// WordPress is now loaded, so other checks can run
 		$searcher = new \Pantheon\Filesearcher( WP_CONTENT_DIR );
 		$searcher->register( new \Pantheon\Checks\Sessions() );

--- a/php/commands/launchcheck.php
+++ b/php/commands/launchcheck.php
@@ -29,6 +29,9 @@ class LaunchCheck {
 			return;
 		}
 
+		// wp-config is going to be loaded again, and we need to avoid notices
+		@WP_CLI::get_runner()->load_wordpress();
+
 		// WordPress is now loaded, so other checks can run
 		$searcher = new \Pantheon\Filesearcher( WP_CONTENT_DIR );
 		$searcher->register( new \Pantheon\Checks\Sessions() );

--- a/php/commands/launchcheck.php
+++ b/php/commands/launchcheck.php
@@ -13,16 +13,21 @@ class LaunchCheck {
 	 *
 	 * ## OPTIONS
 	 *
+	 * @when before_wp_load
 	 */
 	public function all($args, $assoc_args) {
+		// Runs before WordPress loads
+		$checker = new \Pantheon\Checker();
+		$checker->register( new \Pantheon\Checks\Config() );
+		$checker->execute();
+
+		// WordPress is now loaded, so other checks can run
 		$searcher = new \Pantheon\Filesearcher( WP_CONTENT_DIR );
 		$searcher->register( new \Pantheon\Checks\Sessions() );
 		$searcher->register( new \Pantheon\Checks\Insecure() );
 		$searcher->register( new \Pantheon\Checks\Exploited() );
 		$searcher->execute();
-		$checker = new \Pantheon\Checker();
 		$checker->register( new \Pantheon\Checks\Plugins(isset($assoc_args['all'])) );
-		$checker->register( new \Pantheon\Checks\Config() );
 		$checker->register( new \Pantheon\Checks\Cron() );
 		$checker->register( new \Pantheon\Checks\Objectcache() );
 		$checker->register( new \Pantheon\Checks\Database() );
@@ -38,7 +43,8 @@ class LaunchCheck {
 	 * 
 	 * [--format=<json>] 
 	 * : use to output json
-	 * 
+	 *
+	 * @when before_wp_load
 	 */
 	function config($args, $assoc_args) {
 		$checker = new \Pantheon\Checker();

--- a/php/pantheon/checks/config.php
+++ b/php/pantheon/checks/config.php
@@ -9,7 +9,7 @@ use Pantheon\View;
 class Config extends Checkimplementation {
 
 	private $run_once = false;
-	private $valid_db = true;
+	public $valid_db = true;
 
 	public function init() {
 		$this->name = 'config';

--- a/php/pantheon/checks/config.php
+++ b/php/pantheon/checks/config.php
@@ -92,6 +92,7 @@ class Config extends Checkimplementation {
 				'message' => 'Some database constants differ from their expected $_ENV values: ' . implode( ', ' , $different_values ),
 			);
 			$this->valid_db = false;
+			$this->action = 'Please <a href="https://pantheon.io/docs/wp-config-php/">update your wp-config.php</a> file to support $_ENV-based configuration values.';
 		} else {
 			$this->alerts[]  = array(
 				'code'  => 0,

--- a/php/pantheon/checks/config.php
+++ b/php/pantheon/checks/config.php
@@ -38,10 +38,6 @@ class Config extends Checkimplementation {
 		$this->checkNoServerNameWPHomeSiteUrl();
 		$this->checkUsesEnvDBConfig();
 
-		// wp-config is going to be loaded again, and we need to avoid notices
-		if ( $this->valid_db ) {
-			@$runner->load_wordpress();
-		}
 		$this->run_once = true;
 
 		return $this;


### PR DESCRIPTION
While an alternative would be to grep `wp-config.php` for use of
`$_ENV['DB_HOST']`, etc., the only way to truly check that DB constants
are set by `$_ENV` is to modify the launch check bootstrap process such
that the config checks happen after `wp-config.php` is loaded into
scope, but before the rest of WordPress is loaded. If the rest of
WordPress is loaded with invalid database credentials, then WP-CLI will
error.

Fixes #17