### PR TITLE
Bail early when the `cron` option is empty

### DIFF
--- a/features/cron.feature
+++ b/features/cron.feature
@@ -68,3 +68,16 @@ Feature: Check crons
       """
       This is too many to display and may indicate a problem with your site.
       """
+
+  Scenario: Cron check catches when there aren't any crons registered on the site
+    When I run `wp option delete cron`
+    Then STDOUT should contain:
+      """
+      Success: Deleted 'cron' option.
+      """
+
+    When I run `wp launchcheck cron`
+    Then STDOUT should contain:
+      """
+      There don't appear to be any crons registered on this site.
+      """

--- a/php/pantheon/checks/cron.php
+++ b/php/pantheon/checks/cron.php
@@ -53,6 +53,14 @@ class Cron extends Checkimplementation {
 
 		$this->cron_rows = array();
 		$cron = get_option('cron');
+		if ( empty( $cron ) ) {
+			$this->alerts[] = array(
+				'class'   => 'pass',
+				'message' => "There don't appear to be any crons registered on this site.",
+				'code'    => 0,
+			);
+			return;
+		}
 
 		// Count the cron jobs and alert if there are an excessive number scheduled.
 		$job_name_counts = array();


### PR DESCRIPTION
Fixes #65
