### PR TITLE
Add the word WordPress to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![WPLC Logo](https://pantheon.io/sites/default/files/wplc.png)
 
 # WP Launch Check
-WP Launch Check is an extension for WP-CLI designed for Pantheon.io customers. While designed initially for the Pantheon dashboard it is intended to be fully usable outside of Pantheon. 
+WP Launch Check is an extension for WP-CLI designed for Pantheon.io WordPress customers. While designed initially for the Pantheon dashboard it is intended to be fully usable outside of Pantheon. 
 
 To use WP Launch Check simply run the ```wp launchcheck <subcommand>``` command like you would any other WP-CLI command.
 


### PR DESCRIPTION
This project was very hard to locate in both github and Google because the word "WordPress" doesn't appear on the page.