### PR TITLE
Adding check for core version to general command

### DIFF
--- a/features/general.feature
+++ b/features/general.feature
@@ -64,7 +64,7 @@ Feature: General tests of WP Launch Check
 
   Scenario: WordPress has a new major version but no new minor version
     Given a WP install
-    And I run `wp core download --version=4.4.5 --force`
+    And I run `wp core download --version=4.5.6 --force`
     And I run `wp theme activate twentyfifteen`
 
     When I run `wp launchcheck general`

--- a/features/general.feature
+++ b/features/general.feature
@@ -41,3 +41,34 @@ Feature: General tests of WP Launch Check
       """
       WordPress domains are verified to be in sync with Pantheon domains.
       """
+
+  Scenario: WordPress is up to date
+    Given a WP install
+
+    When I run `wp launchcheck general`
+    Then STDOUT should contain:
+      """
+      WordPress is at the latest version.
+      """
+
+  Scenario: WordPress has a new minor version but no new major version
+    Given a WP install
+    And I run `wp core download --version=4.5.1 --force`
+    And I run `wp theme activate twentyfifteen`
+
+    When I run `wp launchcheck general`
+    Then STDOUT should contain:
+      """
+      Updating to WordPress' newest minor version is strongly recommended.
+      """
+
+  Scenario: WordPress has a new major version but no new minor version
+    Given a WP install
+    And I run `wp core download --version=4.4.5 --force`
+    And I run `wp theme activate twentyfifteen`
+
+    When I run `wp launchcheck general`
+    Then STDOUT should contain:
+      """
+      A new major version of WordPress is available for update.
+      """

--- a/features/general.feature
+++ b/features/general.feature
@@ -53,7 +53,7 @@ Feature: General tests of WP Launch Check
 
   Scenario: WordPress has a new minor version but no new major version
     Given a WP install
-    And I run `wp core download --version=4.5.1 --force`
+    And I run `wp core download --version=4.6.1 --force`
     And I run `wp theme activate twentyfifteen`
 
     When I run `wp launchcheck general`

--- a/php/pantheon/checks/general.php
+++ b/php/pantheon/checks/general.php
@@ -216,6 +216,5 @@ class General extends Checkimplementation {
 				'message' => 'WordPress is at the latest version.',
 			);
 		}
-
 	}
 }

--- a/php/pantheon/checks/general.php
+++ b/php/pantheon/checks/general.php
@@ -5,6 +5,7 @@ use Pantheon\Utils;
 use Pantheon\Checkimplementation;
 use Pantheon\Messenger;
 use Pantheon\View;
+use WP_CLI;
 
 class General extends Checkimplementation {
 
@@ -183,14 +184,7 @@ class General extends Checkimplementation {
 	}
 
 	public function checkCoreUpdates() {
-
-		ob_start();
-		\WP_CLI::run_command(array(
-			'core',
-			'check-update'
-		), array('format' => 'json'));
-		$ret = ob_get_clean();
-		$updates = !empty($ret) ? json_decode($ret, TRUE) : array();
+		$updates = WP_CLI::runcommand( 'core check-update --format=json', array( 'return' => true, 'parse' => 'json' ) );
 		$has_minor = $has_major = FALSE;
 		foreach ($updates as $update) {
 			switch ($update['update_type']) {


### PR DESCRIPTION
Fulfills https://github.com/pantheon-systems/wp_launch_check/issues/64. Better late than never?

@danielbachhuber, I copied the logic over from https://github.com/wp-cli/doctor-command/blob/master/inc/checks/class-core-update.php Can I get your thoughts on testing? It looks like I could copy from https://github.com/wp-cli/wp-cli/blob/master/features/core-update.feature#L164 to force the install of old versions of WordPress.