### PR TITLE
Set a default `$next` to ensure `(PAST DUE)` isn't erroneously applied

### DIFF
--- a/php/pantheon/checks/cron.php
+++ b/php/pantheon/checks/cron.php
@@ -78,6 +78,8 @@ class Cron extends Checkimplementation {
 					$past++;
 					$class = "error";
 					$next = date('M j, Y @ H:i:s', $timestamp) . ' (PAST DUE)';
+				} else {
+					$next = date( 'M j, Y @ H:i:s', $timestamp );
 				}
 				$this->cron_rows[] = array('class' => $class, 'data' => array('jobname' => $job, 'schedule' => $data['schedule'], 'next' => $next));
 				$total++;


### PR DESCRIPTION
The prior condition of the loop was that, if `$next` were assigned at any point in execution, then it would apply for the entirety of the loop (or until assigned again).

See #85