### PR TITLE
Add skipped "launchcheck" command in example

### DIFF
--- a/php/commands/launchcheck.php
+++ b/php/commands/launchcheck.php
@@ -152,7 +152,7 @@ class LaunchCheck {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *   wp secure --skip=wp-content/themes
+	 *   wp launchcheck secure --skip=wp-content/themes
 	 *
 	 */
 	public function secure($args, $assoc_args) {


### PR DESCRIPTION
The example command for `wp launchcheck secure` was missing the `launchcheck` part.