### PR TITLE
[BUGS-2788] Use `wp_kses_post` and `esc_attr` instead of `htmlspecialchars`

### DIFF
--- a/php/pantheon/view.php
+++ b/php/pantheon/view.php
@@ -14,7 +14,7 @@ class View {
 	 **/
 	static function make($view, $data) {
 		@\WP_CLI::get_runner()->load_wordpress();
-		require_once \WP_CLI::get_config('path') . '/wp-includes/formatting.php';
+		require_once \WP_CLI\Utils::get_home_dir() . '/wp-load.php';
 
 		ob_start();
 		if (file_exists(__DIR__.self::$viewsdir."/$view.php")) {

--- a/php/pantheon/view.php
+++ b/php/pantheon/view.php
@@ -13,6 +13,9 @@ class View {
 	 * @return array an array of matched files or empty if none found
 	 **/
 	static function make($view, $data) {
+		@\WP_CLI::get_runner()->load_wordpress();
+		require_once \WP_CLI::get_config('path') . '/wp-includes/formatting.php';
+
 		ob_start();
 		if (file_exists(__DIR__.self::$viewsdir."/$view.php")) {
 			extract($data);

--- a/php/pantheon/views/checklist.php
+++ b/php/pantheon/views/checklist.php
@@ -1,5 +1,7 @@
 <ul class="check-list">
 <?php foreach($rows as $row): ?>
-	<li class="severity-<?php echo htmlspecialchars($row['class']); ?>"><p class="result"><?php echo htmlspecialchars($row['message']); ?></p></li>
+	<li class="severity-<?php echo esc_attr($row['class']); ?>">
+		<p class="result"><?php echo wp_kses_post($row['message']); ?></p>
+	</li>
 <?php endforeach; ?>
 </ul>

--- a/php/pantheon/views/checklist.php
+++ b/php/pantheon/views/checklist.php
@@ -1,7 +1,7 @@
 <ul class="check-list">
 <?php foreach($rows as $row): ?>
-	<li class="severity-<?php require_once \WP_CLI::get_config('path') . '/wp-includes/formatting.php'; echo esc_attr($row['class']); ?>">
-		<p class="result"><?php require_once \WP_CLI::get_config('path') . '/wp-includes/formatting.php'; echo wp_kses_post($row['message']); ?></p>
+	<li class="severity-<?php echo esc_attr($row['class']); ?>">
+		<p class="result"><?php echo wp_kses_post($row['message']); ?></p>
 	</li>
 <?php endforeach; ?>
 </ul>

--- a/php/pantheon/views/checklist.php
+++ b/php/pantheon/views/checklist.php
@@ -1,7 +1,7 @@
 <ul class="check-list">
 <?php foreach($rows as $row): ?>
-	<li class="severity-<?php echo esc_attr($row['class']); ?>">
-		<p class="result"><?php echo wp_kses_post($row['message']); ?></p>
+	<li class="severity-<?php require_once \WP_CLI::get_config('path') . '/wp-includes/formatting.php'; echo esc_attr($row['class']); ?>">
+		<p class="result"><?php require_once \WP_CLI::get_config('path') . '/wp-includes/formatting.php'; echo wp_kses_post($row['message']); ?></p>
 	</li>
 <?php endforeach; ?>
 </ul>

--- a/php/pantheon/views/table.php
+++ b/php/pantheon/views/table.php
@@ -3,16 +3,16 @@
 			<tr>
 				<?php if(isset($headers)): ?>
 					<?php foreach ($headers as $header): ?>
-						<th><?php echo htmlspecialchars($header); ?></th>
+						<th><?php echo wp_kses_post($header); ?></th>
 					<?php endforeach; ?>
 				<?php endif; ?>
 			</tr>
 	</thead>
 	<tbody>
 			<?php foreach($rows as $row): ?>
-				<tr class="<?php if(isset($row['class'])) { echo htmlspecialchars($row['class']); } ?>">
+				<tr class="<?php if(isset($row['class'])) { echo esc_attr($row['class']); } ?>">
 					<?php foreach($row['data'] as $values): ?>
-						<td><?php echo htmlspecialchars($values); ?></td>
+						<td><?php echo wp_kses_post($values); ?></td>
 					<?php endforeach; ?>
 				</tr>
 			<?php endforeach; ?>

--- a/php/pantheon/views/table.php
+++ b/php/pantheon/views/table.php
@@ -3,16 +3,16 @@
 			<tr>
 				<?php if(isset($headers)): ?>
 					<?php foreach ($headers as $header): ?>
-						<th><?php require_once \WP_CLI::get_config('path') . '/wp-includes/formatting.php'; echo wp_kses_post($header); ?></th>
+						<th><?php echo wp_kses_post($header); ?></th>
 					<?php endforeach; ?>
 				<?php endif; ?>
 			</tr>
 	</thead>
 	<tbody>
 			<?php foreach($rows as $row): ?>
-				<tr class="<?php require_once \WP_CLI::get_config('path') . '/wp-includes/formatting.php'; if(isset($row['class'])) { echo esc_attr($row['class']); } ?>">
+				<tr class="<?php if(isset($row['class'])) { echo esc_attr($row['class']); } ?>">
 					<?php foreach($row['data'] as $values): ?>
-						<td><?php require_once \WP_CLI::get_config('path') . '/wp-includes/formatting.php'; echo wp_kses_post($values); ?></td>
+						<td><?php echo wp_kses_post($values); ?></td>
 					<?php endforeach; ?>
 				</tr>
 			<?php endforeach; ?>

--- a/php/pantheon/views/table.php
+++ b/php/pantheon/views/table.php
@@ -3,16 +3,16 @@
 			<tr>
 				<?php if(isset($headers)): ?>
 					<?php foreach ($headers as $header): ?>
-						<th><?php echo wp_kses_post($header); ?></th>
+						<th><?php require_once \WP_CLI::get_config('path') . '/wp-includes/formatting.php'; echo wp_kses_post($header); ?></th>
 					<?php endforeach; ?>
 				<?php endif; ?>
 			</tr>
 	</thead>
 	<tbody>
 			<?php foreach($rows as $row): ?>
-				<tr class="<?php if(isset($row['class'])) { echo esc_attr($row['class']); } ?>">
+				<tr class="<?php require_once \WP_CLI::get_config('path') . '/wp-includes/formatting.php'; if(isset($row['class'])) { echo esc_attr($row['class']); } ?>">
 					<?php foreach($row['data'] as $values): ?>
-						<td><?php echo wp_kses_post($values); ?></td>
+						<td><?php require_once \WP_CLI::get_config('path') . '/wp-includes/formatting.php'; echo wp_kses_post($values); ?></td>
 					<?php endforeach; ?>
 				</tr>
 			<?php endforeach; ?>


### PR DESCRIPTION
New PR from https://github.com/pantheon-systems/wp_launch_check/pull/97.

Use `wp_kses_post` to sanitize content for allowed HTML tags for post content.
https://developer.wordpress.org/reference/functions/wp_kses_post/

Use `esc_attr` to escape for HTML attributes.
https://developer.wordpress.org/reference/functions/esc_attr/