### PR TITLE
[BUGS-2865] Fix misspelled Class

### DIFF
--- a/php/pantheon/checks/sessions.php
+++ b/php/pantheon/checks/sessions.php
@@ -24,7 +24,7 @@ class Sessions extends Checkimplementation {
 		$regex = '.*(session_start|\$_SESSION).*';
 		preg_match('#'.$regex.'#s',$file->getContents(), $matches, PREG_OFFSET_CAPTURE );
 		if ( $matches ) {
-                        $matches = Util::sanitize_data($matches);
+                        $matches = Utils::sanitize_data($matches);
 			$note = '';
 			if (count($matches) > 1) {
 				array_shift($matches);


### PR DESCRIPTION
Getting a PHP Fatal error:  Uncaught Error: Class 'Pantheon\Checks\Util' I believe it is misspelled and should be `Utils`