### PR TITLE
command typo: objectcache > object_cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Below is a summary of the available commands. *Full technical description of eac
   * **wp launchcheck cron** : Checks whether cron is enabled and what jobs are scheduled
   * **wp launchcheck general**: General checks for data and best practice, i.e. are you running the debug-bar plugin or have WP_DEBUG defined? This will tell you. 
   * **wp launchcheck database**: Checks related to the databases.
-  * **wp launchcheck objectcache**: Checks whether object caching is enabled and if on Pantheon whether redis is enabled.
+  * **wp launchcheck object_cache**: Checks whether object caching is enabled and if on Pantheon whether redis is enabled.
   * **wp launchcheck sessions**: Checks for plugins refering to the php session_start() function or the superglobal ```$SESSION``` variable. In either case, if you are on a cloud/distributed platform you will need additional configuration achieve the expected functionality
   * **wp launchcheck secure**: Does some rudimentary security checks
   * **wp launchcheck plugins**: Checks plugins for updates and known vulnerabilities


### PR DESCRIPTION
Correct command name is object_cache: 

```
$ terminus wp site.live -- launchcheck objectcache
Error: 'objectcache' is not a registered subcommand of 'launchcheck'. See 'wp help launchcheck' for available subcommands.
Did you mean 'object_cache'?
 [notice] Command: site.live -- wp launchcheck objectcache [Exit: 1]
 [error]


$ terminus wp site.live -- launchcheck object_cache
--------------------------------------------------------------------------------
OBJECT CACHE: (Checking the object caching is on and responding.)
--------------------------------------------------------------------------------
Result: <ul class="check-list">
	<li class="severity-warning"><p class="result">object-cache.php exists</p></li>
	<li class="severity-warning"><p class="result">Redis found</p></li>
</ul>

Recommendation: You should use object caching
```