### PR TITLE
[CMS-606] Don't error if the token is missing

### DIFF
--- a/php/pantheon/checks/plugins.php
+++ b/php/pantheon/checks/plugins.php
@@ -42,7 +42,7 @@ class Plugins extends Checkimplementation {
 			if (stripos($plugin_path,'/')) {
 				$slug = substr($plugin_path, 0, stripos($plugin_path,'/'));
 			}
-			
+
 			$vulnerable = $this->is_vulnerable($slug, $data['Version']);
 
 			$needs_update = 0;
@@ -56,13 +56,13 @@ class Plugins extends Checkimplementation {
 			} else {
 				$vulnerable = sprintf('<a href="https://wpvulndb.com/plugins/%s" target="_blank" >more info</a>', $slug );
 			}
-			
+
 			$report[$slug] = array(
 				'slug' => $slug,
 				'installed' => (string) $data['Version'],
 				'available' => (string) $available,
 				'needs_update' => (string) $needs_update,
-				'vulnerable'  => $vulnerable, 
+				'vulnerable'  => $vulnerable,
 			);
 		}
 		$this->alerts = $report;
@@ -81,7 +81,8 @@ class Plugins extends Checkimplementation {
 
 		// Throw an exception if there is no token
 		if( false === $wpvulndb_api_token || empty( $wpvulndb_api_token ) ) {
-			throw new \Exception('No WP Vulnerability DB API Token. Please ensure the PANTHEON_WPVULNDB_API_TOKEN environment variable is set');
+			//TODO: return a value indicating no scan was performed.
+			return false;
 		}
 
 		// Set the request URL to the requested plugin
@@ -148,7 +149,7 @@ class Plugins extends Checkimplementation {
 
 		// Loop through all vulnerabilities
 		foreach ( $plugin_results['vulnerabilities'] as $vulnerability ) {
-			
+
 			// If the vulnerability hasn't been fixed, then there's an issue
 			if ( ! isset( $vulnerability['fixed_in'] ) ) {
 				return $vulnerability;


### PR DESCRIPTION
This PR has been tested on production using tagged deploys.  See the notes in CMS-606 for details.

The change is on lines 84-85 and some formatting (thanks to my IDE).