### PR TITLE
[CMS-605] Bump major update version

### DIFF
--- a/features/general.feature
+++ b/features/general.feature
@@ -64,7 +64,7 @@ Feature: General tests of WP Launch Check
 
   Scenario: WordPress has a new major version but no new minor version
     Given a WP install
-    And I run `wp core download --version=5.8.3 --force`
+    And I run `wp core download --version=5.8.4 --force`
     And I run `wp theme activate twentytwentytwo`
 
     When I run `wp launchcheck general`


### PR DESCRIPTION
I opened CMS-620

This PR is to update the scenario for the major version that is failing since when I updated them in #115.

```
Scenario: WordPress has a new major version but no new minor version                          # features/general.feature:65
    Given a WP install                                                                          # features/steps/given.php:47
    And I run `wp core download --version=5.8.3 --force`                                        # features/steps/when.php:24
    And I run `wp theme activate twentytwentytwo`                                               # features/steps/when.php:24
    When I run `wp launchcheck general`                                                         # features/steps/when.php:24
    Then STDOUT should contain:                                                                 # features/steps/then.php:15
      """
      A new major version of WordPress is available for update.
      """
      $ wp launchcheck general
      --------------------------------------------------------------------------------
      BEST PRACTICE: (Checking for WordPress best practice) 
      --------------------------------------------------------------------------------
      Result: <ul class="check-list">
      	<li class="severity-ok"><p class="result">WP_DEBUG not found or is set to false.</p></li>
      	<li class="severity-ok"><p class="result">W3 Total Cache not found.</p></li>
      	<li class="severity-ok"><p class="result">WP Super Cache not found.</p></li>
      	<li class="severity-ok"><p class="result">0 active plugins found.</p></li>
      	<li class="severity-ok"><p class="result">Site and home url settings match. ( http://example.com/ )</p></li>
      	<li class="severity-error"><p class="result">Updating to WordPress' newest minor version is strongly recommended.</p></li>
      </ul>
      
      Recommendation: You should use object caching
      
      
      
      cwd: /tmp/wp-cli-test-run-623cdfce8c9428.18849320/
      exit status: 0
```