### PR TITLE
[CMS-392] Update behat tests to match language from cron checks

### DIFF
--- a/features/cron.feature
+++ b/features/cron.feature
@@ -39,7 +39,7 @@ Feature: Check crons
     When I run `wp --require=local-config.php launchcheck cron`
     Then STDOUT should contain:
       """
-      Cron appears to be disabled, make sure DISABLE_WP_CRON is not defined in your wp-config.php
+      WP-Cron is disabled.  Pantheon is running `wp cron event run --due-now` once per hour.
       """
 
     When I run `wp launchcheck cron`


### PR DESCRIPTION
This is additional work that should have been part of #111.

Behat error: https://github.com/pantheon-systems/wp_launch_check/runs/5683321456?check_suite_focus=true

```
Scenario: WP Launch Check warns when DISABLE_WP_CRON is defined to be true                    # features/cron.feature:32
    Given a local-config.php file:                                                              # features/steps/given.php:20
      """
      <?php
      define( 'DISABLE_WP_CRON', true );
      """
    When I run `wp --require=local-config.php launchcheck cron`                                 # features/steps/when.php:24
    Then STDOUT should contain:                                                                 # features/steps/then.php:15
      """
      Cron appears to be disabled, make sure DISABLE_WP_CRON is not defined in your wp-config.php
      """
      $ wp --require=local-config.php launchcheck cron
      --------------------------------------------------------------------------------
      CRON: (Checking whether cron is enabled and what jobs are scheduled) 
      --------------------------------------------------------------------------------
      Result: Checking whether cron is enabled and what jobs are scheduled
      <ul class="check-list">
      	<li class="severity-error"><p class="result">WP-Cron is disabled.  Pantheon is running `wp cron event run --due-now` once per hour.</p></li>
<snip>
```