### PR TITLE
Fix fatals when API token is not found

### DIFF
--- a/php/pantheon/checks/plugins.php
+++ b/php/pantheon/checks/plugins.php
@@ -79,9 +79,8 @@ class Plugins extends Checkimplementation {
 		// Get the vulnerability API token from the platform
 		$wpvulndb_api_token = $this->getWpScanApiToken();
 
-		// Throw an exception if there is no token
+		// Fail silently if there is no API token.
 		if( false === $wpvulndb_api_token || empty( $wpvulndb_api_token ) ) {
-			//TODO: return a value indicating no scan was performed.
 			return false;
 		}
 

--- a/php/pantheon/checks/themes.php
+++ b/php/pantheon/checks/themes.php
@@ -91,9 +91,9 @@ class Themes extends Checkimplementation {
 		// Get the vulnerability API token from the platform
 		$wpvulndb_api_token = getenv('PANTHEON_WPVULNDB_API_TOKEN');
 
-		// Throw an exception if there is no token
+		// Fail silently if there is no API token.
 		if( false === $wpvulndb_api_token || empty( $wpvulndb_api_token ) ) {
-			throw new \Exception('No WP Vulnerability DB API Token. Please ensure the PANTHEON_WPVULNDB_API_TOKEN environment variable is set');
+			return false;
 		}
 
 		// Set the request URL to the requested theme


### PR DESCRIPTION
We should not throw fatal errors if no vulnerability API token is found.

This PR updates the comments in `php/pantheon/checks/plugins.php` to reflect the current code that's there (removes the comment about throwing an exception), and updates `php/pantheon/checks/themes.php` to match.

This should resolve the behat tests failing due to lack of API token.