### PR TITLE
[CMS-845] Don't recommend Native PHP Sessions if it's already installed

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,7 +76,7 @@ jobs:
           mkdir -p $WP_CLI_BIN_DIR
           curl -s https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > $WP_CLI_BIN_DIR/wp
           chmod +x $WP_CLI_BIN_DIR/wp
-          wp core version
+          $WP_CLI_BIN_DIR/wp core version
 
       - name: Generate Phar
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,7 +76,6 @@ jobs:
           mkdir -p $WP_CLI_BIN_DIR
           curl -s https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > $WP_CLI_BIN_DIR/wp
           chmod +x $WP_CLI_BIN_DIR/wp
-          $WP_CLI_BIN_DIR/wp core version
 
       - name: Generate Phar
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,6 +76,7 @@ jobs:
           mkdir -p $WP_CLI_BIN_DIR
           curl -s https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > $WP_CLI_BIN_DIR/wp
           chmod +x $WP_CLI_BIN_DIR/wp
+          wp core version
 
       - name: Generate Phar
         run: |

--- a/features/general.feature
+++ b/features/general.feature
@@ -45,6 +45,9 @@ Feature: General tests of WP Launch Check
   Scenario: WordPress is up to date
     Given a WP install
 
+		When I run `wp core version`
+		Then STDOUT should not be empty
+
     When I run `wp launchcheck general`
     Then STDOUT should contain:
       """

--- a/features/general.feature
+++ b/features/general.feature
@@ -46,7 +46,10 @@ Feature: General tests of WP Launch Check
     Given a WP install
 
 		When I run `wp core version`
-		Then STDOUT should not be empty
+		Then STDOUT should contain:
+			"""
+			6.0
+			"""
 
     When I run `wp launchcheck general`
     Then STDOUT should contain:

--- a/features/general.feature
+++ b/features/general.feature
@@ -46,6 +46,7 @@ Feature: General tests of WP Launch Check
     Given a WP install
 
 		When I run `wp core version`
+		# This check is here to remind us to update versions when new releases are available.
 		Then STDOUT should contain:
 			"""
 			6.0

--- a/features/general.feature
+++ b/features/general.feature
@@ -45,12 +45,12 @@ Feature: General tests of WP Launch Check
   Scenario: WordPress is up to date
     Given a WP install
 
-		When I run `wp core version`
-		# This check is here to remind us to update versions when new releases are available.
-		Then STDOUT should contain:
-			"""
-			6.0
-			"""
+    When I run `wp core version`
+    # This check is here to remind us to update versions when new releases are available.
+    Then STDOUT should contain:
+      """
+      6.0
+      """
 
     When I run `wp launchcheck general`
     Then STDOUT should contain:

--- a/features/general.feature
+++ b/features/general.feature
@@ -70,7 +70,7 @@ Feature: General tests of WP Launch Check
 
   Scenario: WordPress has a new major version but no new minor version
     Given a WP install
-    And I run `wp core download --version=5.8.4 --force`
+    And I run `wp core download --version=5.8.5 --force`
     And I run `wp theme activate twentytwentytwo`
 
     When I run `wp launchcheck general`

--- a/features/sessions.feature
+++ b/features/sessions.feature
@@ -6,7 +6,7 @@ Feature: Test for the existence of the PHP Native Sessions plugin
     When I run `wp launchcheck sessions`
     Then STDOUT should contain:
       """
-      You should install the Native PHP Sessions plugin
+      Recommendation: You should install the Native PHP Sessions plugin - https://wordpress.org/plugins/wp-native-php-sessions/
       """
 
   Scenario: A WordPress install with the native sessions plugin installed but not active
@@ -16,7 +16,7 @@ Feature: Test for the existence of the PHP Native Sessions plugin
 	When I run `wp launchcheck sessions`
 	Then STDOUT should contain:
 	  """
-	  You should isntall the Native PHP Sessions plugin
+	  Recommendation: You should install the Native PHP Sessions plugin - https://wordpress.org/plugins/wp-native-php-sessions/
 	  """
 
   Scenario: A WordPress install with the native sessions plugin installed and active
@@ -27,5 +27,5 @@ Feature: Test for the existence of the PHP Native Sessions plugin
 	When I run `wp launchcheck sessions`
 	Then STDOUT should contain:
 	  """
-	  No action required
+	  Recommendation: No action required
 	  """

--- a/features/sessions.feature
+++ b/features/sessions.feature
@@ -1,0 +1,31 @@
+Feature: Test for the existence of the PHP Native Sessions plugin
+
+  Scenario: A WordPress install without the native sessions plugin
+    Given a WP install
+
+    When I run `wp launchcheck sessions`
+    Then STDOUT should contain:
+      """
+      You should install the Native PHP Sessions plugin
+      """
+
+  Scenario: A WordPress install with the native sessions plugin installed but not active
+    Given a WP install
+	And I run `wp plugin install wp-native-php-sessions`
+
+	When I run `wp launchcheck sessions`
+	Then STDOUT should contain:
+	  """
+	  You should isntall the Native PHP Sessions plugin
+	  """
+
+  Scenario: A WordPress install with the native sessions plugin installed and active
+	Given a WP install
+	And I run `wp plugin install wp-native-php-sessions`
+	And I run `wp plugin activate wp-native-php-sessions`
+
+	When I run `wp launchcheck sessions`
+	Then STDOUT should contain:
+	  """
+	  No action required
+	  """

--- a/php/pantheon/checks/general.php
+++ b/php/pantheon/checks/general.php
@@ -37,7 +37,7 @@ class General extends Checkimplementation {
 				'class' => 'warning',
 				'message' => 'W3 Total Cache plugin found. This plugin is not needed on Pantheon and should be removed.',
 			);
-		} else {  
+		} else {
 			$this->alerts[] = array(
 				'code' => 0,
 				'class' => 'ok',
@@ -50,7 +50,7 @@ class General extends Checkimplementation {
 				'class' => 'warning',
 				'message' => 'WP Super Cache plugin found. This plugin is not needed on Pantheon and should be removed.',
 			);
-		} else { 
+		} else {
 			$this->alerts[] = array(
 				'code' => 0,
 				'class' => 'ok',
@@ -64,13 +64,13 @@ class General extends Checkimplementation {
 		$siteurl = \get_option('siteurl');
 		$home = \get_option('home');
 		if ( $siteurl !== $home ) {
-			$this->alerts[] = array( 
+			$this->alerts[] = array(
 				'code'  =>  2,
 				'class' => 'error',
 				'message' => "Site url and home settings do not match. ( 'siteurl'=$siteurl and 'home'=>$home )",
 			);
 		} else {
-			$this->alerts[] = array( 
+			$this->alerts[] = array(
 				'code'  =>  0,
 				'class' => 'ok',
 				'message' => "Site and home url settings match. ( $siteurl )",
@@ -82,19 +82,19 @@ class General extends Checkimplementation {
 		$active = get_option('active_plugins');
 		$plugins = count($active);
 		if ( 100 <= $plugins ) {
-			$this->alerts[] = array(  
+			$this->alerts[] = array(
 				'code' => 1,
 				'class' => 'warning',
 				'message' =>  sprintf('%d active plugins found. You are running more than 100 plugins. The more plugins you run the worse your performance will be. You should uninstall any plugin that is not necessary.', $plugins),
 			);
-		} else { 
+		} else {
 			$this->alerts[] = array(
 				'code'  => 0,
 				'class' => 'ok',
 				'message' => sprintf('%d active plugins found.',$plugins),
 			);
 		}
-	} 
+	}
 
 	public function checkDebug() {
 
@@ -113,7 +113,7 @@ class General extends Checkimplementation {
 				);
 			}
 		} else {
-			$this->alerts[]  = array( 
+			$this->alerts[]  = array(
 				'code'  => 0,
 				'class' => 'ok',
 				'message' => 'WP_DEBUG not found or is set to false.',
@@ -132,7 +132,7 @@ class General extends Checkimplementation {
 					 'message' => 'Looks like you are running the debug bar plugin. You should disable this plugin in the live environment'
 				);
 			}
-		}   
+		}
 
 	}
 

--- a/php/pantheon/checks/general.php
+++ b/php/pantheon/checks/general.php
@@ -178,7 +178,7 @@ class General extends Checkimplementation {
 				$avg = $total/count($this->alerts);
 				$this->result = View::make('checklist', array('rows'=> $rows) );
 				$this->score = $avg;
-				$this->action = "You should use object caching";
+				$this->action = $this->action ?? "You should use object caching";
 		}
 		$messenger->addMessage(get_object_vars($this));
 	}
@@ -204,6 +204,7 @@ class General extends Checkimplementation {
 				'class' => 'error',
 				'message' => $action,
 			);
+			$this->action = $action;
 		} else if ( $has_major ) {
 			$action= 'A new major version of WordPress is available for update.';
 			$this->alerts[] = array(
@@ -211,6 +212,7 @@ class General extends Checkimplementation {
 				'class'   => 'warning',
 				'message' => $action,
 			);
+			$this->action = $action;
 		} else {
 			$this->alerts[]  = array(
 				'code'  => 0,

--- a/php/pantheon/checks/general.php
+++ b/php/pantheon/checks/general.php
@@ -198,16 +198,18 @@ class General extends Checkimplementation {
 		}
 
 		if ( $has_minor ) {
+			$action = "Updating to WordPress' newest minor version is strongly recommended.";
 			$this->alerts[] = array(
 				'code'  =>  2,
 				'class' => 'error',
-				'message' => "Updating to WordPress' newest minor version is strongly recommended.",
+				'message' => $action,
 			);
 		} else if ( $has_major ) {
+			$action= 'A new major version of WordPress is available for update.';
 			$this->alerts[] = array(
 				'code'    => 1,
 				'class'   => 'warning',
-				'message' => 'A new major version of WordPress is available for update.'
+				'message' => $action,
 			);
 		} else {
 			$this->alerts[]  = array(

--- a/php/pantheon/checks/general.php
+++ b/php/pantheon/checks/general.php
@@ -206,7 +206,7 @@ class General extends Checkimplementation {
 			);
 			$this->action = $action;
 		} else if ( $has_major ) {
-			$action= 'A new major version of WordPress is available for update.';
+			$action = 'A new major version of WordPress is available for update.';
 			$this->alerts[] = array(
 				'code'    => 1,
 				'class'   => 'warning',

--- a/php/pantheon/checks/sessions.php
+++ b/php/pantheon/checks/sessions.php
@@ -17,7 +17,7 @@ class Sessions extends Checkimplementation {
 		$this->has_plugin = class_exists("Pantheon_Sessions");
 		// If the plugin was not found, define the recommended action.
 		// Otherwise, we don't want to recommend anything, we're all good here.
-		$this->action = ! $this->has_plugin ? 'You should install the Native PHP Sessions plugin - https://wordpress.org/plugins/wp-native-php-sessions/' : null;
+		$this->action = ! $this->has_plugin ? 'You should install the Native PHP Sessions plugin - https://wordpress.org/plugins/wp-native-php-sessions/' : 'No action required';
 
 		return $this;
 	}

--- a/php/pantheon/checks/sessions.php
+++ b/php/pantheon/checks/sessions.php
@@ -15,6 +15,10 @@ class Sessions extends Checkimplementation {
 		$this->result = '';
 		$this->label = 'PHP Sessions';
 		$this->has_plugin = class_exists("Pantheon_Sessions");
+		// If the plugin was not found, define the recommended action.
+		// Otherwise, we don't want to recommend anything, we're all good here.
+		$this->action = ! $this->has_plugin ? 'You should install the Native PHP Sessions plugin - https://wordpress.org/plugins/wp-native-php-sessions/' : null;
+
 		return $this;
 	}
 
@@ -31,7 +35,7 @@ class Sessions extends Checkimplementation {
 			foreach ($matches as $match) {
 				$this->alerts[] = array( 'class' => 'error','data'=>array($file->getRelativePathname(),$match[1] + 1, substr($match[0],0,50)));
 			}
-		} 
+		}
 		return $this;
 	}
 

--- a/php/pantheon/checks/sessions.php
+++ b/php/pantheon/checks/sessions.php
@@ -10,8 +10,7 @@ class Sessions extends Checkimplementation {
 	public $name = 'sessions';
 
 	public function init() {
-		$this->action = 'You should install the Native PHP Sessions plugin - https://wordpress.org/plugins/wp-native-php-sessions/';
-		$this->description = 'Sessions only work with sessions plugin is enabled';
+		$this->description = 'Sessions only work when sessions plugin is enabled';
 		$this->score = 0;
 		$this->result = '';
 		$this->label = 'PHP Sessions';

--- a/php/pantheon/messenger.php
+++ b/php/pantheon/messenger.php
@@ -55,6 +55,8 @@ class Messenger {
 						$color = "%R";
 					}
 
+					$recommendation = isset( $message['action'] ) ? sprintf( "Recommendation: %s", $message['action'] ) : '';
+
 					// @todo might be a better way to do this
 					echo \cli\Colors::colorize( sprintf(str_repeat('-',80).PHP_EOL."%s: (%s) \n%s\nResult:%s %s\n%s\n\n".PHP_EOL,
 						strtoupper($message['label']),
@@ -63,8 +65,8 @@ class Messenger {
 						$color,
 						$message['result'].'%n', // ugly
 						// Check for a recommended action before printing something.
-						isset( $message['action'] ) ?? sprintf( "Recommendation: %s", $message['action'] ) )
-					);
+						$recommendation
+					) );
 				}
 				break;
 		}

--- a/php/pantheon/messenger.php
+++ b/php/pantheon/messenger.php
@@ -56,13 +56,14 @@ class Messenger {
 					}
 
 					// @todo might be a better way to do this
-					echo \cli\Colors::colorize( sprintf(str_repeat('-',80).PHP_EOL."%s: (%s) \n%s\nResult:%s %s\nRecommendation: %s\n\n".PHP_EOL,
+					echo \cli\Colors::colorize( sprintf(str_repeat('-',80).PHP_EOL."%s: (%s) \n%s\nResult:%s %s\n%s\n\n".PHP_EOL,
 						strtoupper($message['label']),
 						$message['description'],
 						str_repeat('-',80),
 						$color,
 						$message['result'].'%n', // ugly
-						$message['action'])
+						// Check for a recommended action before printing something.
+						isset( $message['action'] ) ?? sprintf( "Recommendation: %s", $message['action'] ) )
 					);
 				}
 				break;

--- a/php/pantheon/messenger.php
+++ b/php/pantheon/messenger.php
@@ -65,8 +65,8 @@ class Messenger {
 						$color,
 						$message['result'].'%n', // ugly
 						// Check for a recommended action before printing something.
-						$recommendation
-					) );
+						$recommendation )
+					);
 				}
 				break;
 		}


### PR DESCRIPTION
This PR changes how the messenger class works for the Recommendation line to make it so if no action exists, no recommendation is given. It then changes the sessions sub-command to not define a recommended action if the plugin is already installed.

By necessity, this PR also updates some of the general behat tests (specifically around versions) which updated since the last time tests were run.

This PR also adds new behat tests for the `wp launchcheck sessions` subcommand which previously did not exist. The tests check output:

- when the Native PHP Sessions plugin was not installed
- when the Native PHP Sessions plugin is installed but not active (currently outputs the same message)
- when the Native PHP Sessions plugin is installed and active