### PR TITLE
[BUGS-5759] Adjust logic for checking for options table

### DIFF
--- a/features/general.feature
+++ b/features/general.feature
@@ -49,7 +49,7 @@ Feature: General tests of WP Launch Check
     # This check is here to remind us to update versions when new releases are available.
     Then STDOUT should contain:
       """
-      6.0
+      6.1.1
       """
 
     When I run `wp launchcheck general`

--- a/php/pantheon/checks/database.php
+++ b/php/pantheon/checks/database.php
@@ -44,7 +44,7 @@ class Database extends Checkimplementation {
 		global $wpdb;
 		foreach ( $this->getTables() as $table ) {
 			$this->tables[$table->TABLE_NAME] = $table;
-			if ( $wpdb->prefix . 'options' ) { 
+			if ( $table->TABLE_NAME == $wpdb->prefix . 'options' ) { 
 				$options_table = $table;
 				break;
 			}

--- a/php/pantheon/checks/database.php
+++ b/php/pantheon/checks/database.php
@@ -44,7 +44,7 @@ class Database extends Checkimplementation {
 		global $wpdb;
 		foreach ( $this->getTables() as $table ) {
 			$this->tables[$table->TABLE_NAME] = $table;
-			if ( preg_match( "#.*_options#s", $table->TABLE_NAME ) ) { 
+			if ( preg_match( "#.*options#s", $table->TABLE_NAME ) ) { 
 				$options_table = $table;
 				break;
 			}

--- a/php/pantheon/checks/database.php
+++ b/php/pantheon/checks/database.php
@@ -44,7 +44,7 @@ class Database extends Checkimplementation {
 		global $wpdb;
 		foreach ( $this->getTables() as $table ) {
 			$this->tables[$table->TABLE_NAME] = $table;
-			if ( preg_match( "#.*options#s", $table->TABLE_NAME ) ) { 
+			if ( $wpdb->prefix . 'options' ) { 
 				$options_table = $table;
 				break;
 			}

--- a/php/pantheon/checks/database.php
+++ b/php/pantheon/checks/database.php
@@ -44,7 +44,7 @@ class Database extends Checkimplementation {
 		global $wpdb;
 		foreach ( $this->getTables() as $table ) {
 			$this->tables[$table->TABLE_NAME] = $table;
-			if ( $table->TABLE_NAME == $wpdb->prefix . 'options' ) { 
+			if ( $table->TABLE_NAME === $wpdb->prefix . 'options' ) { 
 				$options_table = $table;
 				break;
 			}


### PR DESCRIPTION
Addresses #136 where customers use a custom DB prefix without a trailing `_`.