### PR TITLE
[CMSP-273] Add additional insights for database performance

### DIFF
--- a/php/pantheon/checks/database.php
+++ b/php/pantheon/checks/database.php
@@ -8,6 +8,8 @@ use Pantheon\View;
 
 class Database extends Checkimplementation {
 	public $check_all_plugins;
+	public $performance_tables;
+	public $alerts;
 
 	public function init() {
 		$this->name = 'database';
@@ -17,6 +19,7 @@ class Database extends Checkimplementation {
 		$this->result = '';
 		$this->label = 'Database';
 		$this->alerts = array();
+		$this->performance_tables = array();
 		self::$instance = $this;
 		return $this;
 	}
@@ -25,6 +28,8 @@ class Database extends Checkimplementation {
 		$this->countRows();
 		$this->checkInnoDB();
 		$this->checkTransients();
+		$this->checkDatabaseSize();
+		$this->checkIndexPerformance();
 		return $this;
 	}
 
@@ -44,16 +49,16 @@ class Database extends Checkimplementation {
 		global $wpdb;
 		foreach ( $this->getTables() as $table ) {
 			$this->tables[$table->TABLE_NAME] = $table;
-			if ( $table->TABLE_NAME === $wpdb->prefix . 'options' ) { 
+			if ( $table->TABLE_NAME === $wpdb->prefix . 'options' ) {
 				$options_table = $table;
 				break;
 			}
-		} 
+		}
 		if ($options_table->TABLE_ROWS > 5000) {
 			$this->alerts[] = array('code'=>1, 'message'=> sprintf("Found %s rows in options table which is more than recommended and can cause performance issues", $options_table->TABLE_ROWS), 'class'=>'warning');
 		} else {
 			$this->alerts[] = array('code'=>0, 'message'=> sprintf("Found %s rows in the options table.", $options_table->TABLE_ROWS), 'class'=>'ok');
-		} 
+		}
 
 		$autoloads = $wpdb->get_results("SELECT * FROM " . $wpdb->options . " WHERE autoload = 'yes'");
 		if ( 1000 < count($autoloads) ) {
@@ -99,13 +104,13 @@ class Database extends Checkimplementation {
 		global $wpdb;
 		$query = "SELECT option_name,option_value from " . $wpdb->options . " where option_name LIKE '%_transient_%';";
 		$transients = $wpdb->get_results($query);
-		$this->alerts[] = array( 
+		$this->alerts[] = array(
 			'code'=> 0,
 			'message' => sprintf("Found %d transients.", count($transients) ),
 			'class'=>'ok',
 		);
 		$expired = array();
-		foreach( $transients as $transient ) { 
+		foreach( $transients as $transient ) {
 			$transient->option_name;
 			if ( preg_match( "#^_transient_timeout.*#s", $transient->option_name ) ) {
 				if ($transient->option_value < time()) {
@@ -123,11 +128,118 @@ class Database extends Checkimplementation {
 
 	}
 
+	public function checkDatabaseSize() {
+		global $wpdb;
+		$query = "SELECT table_name AS `table`,
+       			round(((data_length + index_length) / 1024 / 1024), 2) `size`,
+				table_rows AS `rows`
+			  FROM information_schema.TABLES
+			  WHERE table_schema = '$wpdb->dbname'
+			  ORDER BY (data_length + index_length) DESC";
+
+		$tables = $wpdb->get_results($query);
+		$headers = array('Table', 'Size (MB)', 'Rows');
+		$rows = array();
+		foreach( $tables as $table ) {
+			$table_size = number_format($table->size, 2);
+			$class = ($table_size >= 5000) ? 'error' : (($table_size >= 1000) ? 'warning' : 'ok');
+			$row = array();
+			$row['class'] = $class;
+			$row['data'] = array(
+				$table->table,
+				$table_size,
+				number_format($table->rows)
+			);
+			$rows[] = $row;
+		}
+
+		if ($rows) {
+			$this->performance_tables[] = array(
+				'title' => 'Database Size Overview',
+				'headers' => $headers,
+				'rows' => $rows,
+			);
+		}
+	}
+
+	public function checkIndexPerformance() {
+		global $wpdb;
+		$query = "SELECT
+            t.table_name AS `table`,
+            i.index_name AS `index`,
+            round((100 * (1 - (i.cardinality / t.table_rows))), 2) AS `index_select`,
+            round(((t.data_length + t.index_length) / 1024 / 1024), 2) `size`,
+            t.index_length / i.cardinality `avg_length`,
+            t.table_rows AS `rows`
+        FROM information_schema.TABLES t
+            JOIN information_schema.STATISTICS i ON t.table_name = i.table_name AND t.table_schema = i.table_schema
+        WHERE t.table_schema = '$wpdb->dbname'
+            AND i.index_name != 'PRIMARY'
+            AND i.index_name NOT LIKE '%\_unique'
+        ORDER BY `table` ASC, `index` ASC";
+
+		$indexes = $wpdb->get_results($query);
+		$headers = array('Table', 'Index Name', 'Index Selectivity (%)', 'Rows', 'Avg. Length');
+		$rows = array();
+		foreach( $indexes as $index ) {
+			$index_select = number_format($index->index_select, 2);
+
+			$class = 'ok';
+			// Rule of thumb for minimum row count to create an index.
+			if ($index->rows > 2000) {
+				// Check performance of index based on selectivity.
+
+				// RED: Higher than 60% and less than 10%
+				// Selectivity is the ratio of the number of distinct index key values to the number of rows in the table.
+				// A higher selectivity means that the index is more selective and can narrow down the search for a particular value more quickly.
+				// However, if the selectivity is too high (e.g., close to 100%), it means that the index is not very useful
+				// for selective queries because it matches a large percentage of rows in the table.
+				if ($index_select >= 60 || $index_select <= 10) {
+					$class = 'error';
+				}
+				// WARNING: Higher than 10% (less than 20%) and higher than 30% (but less than 60%).
+				 else if (($index_select > 10 && $index_select < 20) || ($index_select > 30 && $index_select < 60)) {
+					$class = 'warning';
+				}
+				 // Sweet spot for selectivity is around 20%-30%, but merely a guide.
+			}
+
+			$row = array();
+			$row['class'] = $class;
+			$row['data'] = array(
+				$index->table,
+				$index->index,
+				$index_select,
+				$index->rows,
+				number_format($index->avg_length),
+			);
+			$rows[] = $row;
+		}
+
+		// Information about the columns in the table.
+		$list = array(
+			'<strong>Table</strong>: The name of the table with the index applied.',
+			'<strong>Index</strong>: The unique name of the index.',
+			'<strong>Index Selectivity</strong>: Selectivity is the ratio of the number of distinct index key values to the number of rows in the table.',
+			'<strong>Rows</strong>: The number of rows in the table.',
+			'<strong>Average Length</strong>: This column shows the average length of each index entry, in bytes. A longer average length can lead to larger index sizes and slower queries due to increased I/O operations.',
+		);
+
+		if ($rows) {
+			$this->performance_tables[] = array(
+				'title' => 'Database Index Performance Overview',
+				'headers' => $headers,
+				'rows' => $rows,
+				'list' => $list,
+			);
+		}
+	}
+
 	public function message(Messenger $messenger) {
 			if (!empty($this->alerts)) {
 				$total = 0;
 				$rows = array();
-				// this is dumb and left over from the previous iterationg. @TODO move scoring to run() method
+				// this is dumb and left over from the previous iteration. @TODO move scoring to run() method
 				foreach ($this->alerts as $alert) {
 					$total += $alert['code'];
 					$rows[] = $alert;
@@ -136,6 +248,16 @@ class Database extends Checkimplementation {
 				$this->result = View::make('checklist', array('rows'=> $rows) );
 				$this->score = round($avg);
 		}
+			if (!empty($this->performance_tables)) {
+				foreach ($this->performance_tables as $table) {
+					$this->result .= "<h4>" . $table['title'] . "</h4>";
+					if (!empty($table['list'])) {
+						$this->result .= View::make('list', ['rows' => $table['list'], 'type' => 'ul']);
+						$this->result .= "<br/>";
+					}
+					$this->result .= View::make('table', array('headers' => $table['headers'], 'rows' => $table['rows'], 'fixed' => TRUE));
+				}
+			}
 		$messenger->addMessage(get_object_vars($this));
 	}
 }

--- a/php/pantheon/view.php
+++ b/php/pantheon/view.php
@@ -7,19 +7,17 @@ class View {
 	/**
 	 * Searches php files for the provided regex
 	 *
-	 * @param $dir string directory to start from
-	 * @param $regex string undelimited pattern to match
-	 *
-	 * @return array an array of matched files or empty if none found
-	 **/
+	 * @param $view
+	 * @param $data
+	 * @return false|string an array of matched files or empty if none found
+	 */
 	static function make($view, $data) {
 		ob_start();
 		if (file_exists(__DIR__.self::$viewsdir."/$view.php")) {
 			extract($data);
 			include(__DIR__.self::$viewsdir."/$view.php");
 		}
-		$out = ob_get_clean();
-		return $out;
+		return ob_get_clean();
 	}
 
 }

--- a/php/pantheon/views/list.php
+++ b/php/pantheon/views/list.php
@@ -1,0 +1,8 @@
+<?php $type = (isset($type) && in_array($type, ['ol', 'ul'])) ? $type : 'ul' ?>
+<?php if (isset($rows)): ?>
+<<?php echo $type; ?> class="generic-list">
+	<?php foreach($rows as $row): ?>
+		<li><?php echo $row; ?></li>
+	<?php endforeach; ?>
+</<?php echo $type; ?>>
+<?php endif; ?>

--- a/php/pantheon/views/table.php
+++ b/php/pantheon/views/table.php
@@ -1,20 +1,22 @@
+<?php if(isset($fixed)): ?>
+<?php $id = "database-table-" . rand(); ?>
+<style>
+	#<?php echo $id; ?>.tableFixHead          { overflow: auto; max-height: 600px; }
+	#<?php echo $id; ?>.tableFixHead thead th { position: sticky; top: 0; z-index: 1; background-color: #E2E2E2; }
+</style>
+<div id="<?php echo $id; ?>" class="tableFixHead">
+<?php endif; ?>
+
 <table class='table table-condensed'>
 	<thead>
-			<tr>
-				<?php if(isset($headers)): ?>
-					<?php foreach ($headers as $header): ?>
-						<th><?php echo $header; ?></th>
-					<?php endforeach; ?>
-				<?php endif; ?>
-			</tr>
+		<tr><?php if(isset($headers)): ?><?php foreach ($headers as $header): ?><th><?php echo $header; ?></th><?php endforeach; ?><?php endif; ?></tr>
 	</thead>
 	<tbody>
-			<?php foreach($rows as $row): ?>
-				<tr class="<?php if(isset($row['class'])) { echo $row['class']; } ?>">
-					<?php foreach($row['data'] as $values): ?>
-						<td><?php echo $values; ?></td>
-					<?php endforeach; ?>
-				</tr>
-			<?php endforeach; ?>
+	<?php if(isset($rows)): ?><?php foreach($rows as $row): ?>
+		<tr class="<?php if(isset($row['class'])) { echo $row['class']; } ?>"><?php foreach($row['data'] as $values): ?><td><?php echo $values; ?></td><?php endforeach; ?></tr>
+<?php endforeach; ?><?php endif; ?>
 	</tbody>
 </table>
+<?php if(isset($fixed)): ?>
+</div>
+<?php endif; ?>


### PR DESCRIPTION
In an effort to start tracking database performance within the dashboard, this adds two additional tables to the Database output section of the status report:

1. Overview of tables sizes with row counts
2. Overview of index on tables with selectivity and index length

This data can serve well for customers who understand a bit about database performance, and can also provide both a customer or CSE a snapshot of the overall database state just by fetching a few pieces of information. I've added some explainer notes as well for what the index columns mean, but doing some research, the index performance is a bit subjective, so I've only added rough guidelines.

I've also added a new template for lists, and added an optional parameter to the table template for adding scrollable tables when the output is very long.

<img width="858" alt="image" src="https://user-images.githubusercontent.com/1759794/224365076-56a04386-df99-440d-b6ff-a76d8bcedd86.png">
