### PR TITLE
Bump WP Core version to 6.2 and 5.6.10

### DIFF
--- a/features/general.feature
+++ b/features/general.feature
@@ -60,7 +60,7 @@ Feature: General tests of WP Launch Check
 
   Scenario: WordPress has a new minor version but no new major version
     Given a WP install
-    And I run `wp core download --version=6.0 --force`
+    And I run `wp core download --version=6.2 --force`
     And I run `wp theme activate twentytwentytwo`
 
     When I run `wp launchcheck general`
@@ -71,7 +71,7 @@ Feature: General tests of WP Launch Check
 
   Scenario: WordPress has a new major version but no new minor version
     Given a WP install
-    And I run `wp core download --version=5.9.5 --force`
+    And I run `wp core download --version=5.6.10 --force`
     And I run `wp theme activate twentytwentytwo`
 
     When I run `wp launchcheck general`


### PR DESCRIPTION
It's intentional that the version(s) being updated to, 6.2 and 5.6.10, are not the latest version(s) available.