### PR TITLE
[CMSP-261] Remove vulnerability column for plugins and themes

### DIFF
--- a/features/theme.feature
+++ b/features/theme.feature
@@ -8,7 +8,7 @@ Feature: Test WordPress for themes with known security issues
     When I run `wp launchcheck all --all`
     Then STDOUT should contain:
       """
-      Found 1 themes needing updates and 0 known vulnerabilities
+      Found 1 themes needing updates
       """
     And STDOUT should contain:
       """
@@ -23,5 +23,5 @@ Feature: Test WordPress for themes with known security issues
     When I run `wp launchcheck all --all`
     Then STDOUT should contain:
       """
-      Found 0 themes needing updates and 0 known vulnerabilities
+      Found 0 themes needing updates
       """

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -8,7 +8,7 @@ Feature: Test WordPress for themes with known security issues
     When I run `wp launchcheck all --all`
     Then STDOUT should contain:
       """
-      Found 1 themes needing updates
+      Found one theme needing updates
       """
     And STDOUT should contain:
       """

--- a/php/pantheon/checks/namespace.php
+++ b/php/pantheon/checks/namespace.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * WP Launch Check common functions
+ *
+ * @package wp_launch_check
+ */
+
+namespace Pantheon\Checks\Common;
+
+/**
+ * Get a WordPress vulnerability API token if one is defined and we're in the right environment.
+ * Copied from wp_launch_check/php/pantheon/checks/plugins.php
+ * Uses the WPSCAN_API_TOKEN constant if defined.
+ *
+ * @return string
+ * @todo Replace this with a Patchstack API token.
+ */
+function get_wp_vuln_api_token() {
+	if ( defined( 'WPSCAN_API_TOKEN' ) ) {
+		// Don't use WPSCAN if PANTHEON_WPSCAN_ENVIRONMENTS have not been specified.
+		if( ! defined( 'PANTHEON_WPSCAN_ENVIRONMENTS' ) ) {
+			return '';
+		}
+
+		$environments = ( ! is_array( PANTHEON_WPSCAN_ENVIRONMENTS ) ) ? explode( ',', PANTHEON_WPSCAN_ENVIRONMENTS ) : PANTHEON_WPSCAN_ENVIRONMENTS;
+
+		// Only run WPSCAN on the specified environments unless it's been configured to run on all (*).
+		if ( in_array( getenv( 'PANTHEON_ENVIRONMENT' ), $environments, true ) || in_array( '*', $environments, true ) ) {
+			return WPSCAN_API_TOKEN;
+		}
+	}
+
+	// TODO: Replace this PANTHEON_WPVULNDB_API_TOKEN with a new Patchstack API token.
+	// return getenv( 'PANTHEON_WPVULNDB_API_TOKEN' );
+	return '';
+}

--- a/php/pantheon/checks/plugins.php
+++ b/php/pantheon/checks/plugins.php
@@ -11,6 +11,8 @@ class Plugins extends Checkimplementation {
 	public $check_all_plugins;
 
 	public function __construct($check_all_plugins) {
+		require_once __DIR__ . '/namespace.php';
+
 		$this->check_all_plugins = $check_all_plugins;
 	}
 
@@ -37,7 +39,7 @@ class Plugins extends Checkimplementation {
 		$all_plugins = Utils::sanitize_data( get_plugins() );
 		$update = Utils::sanitize_data( get_plugin_updates() );
 		$report = array();
-		$should_check_vulnerabilities = $this->getWpScanApiToken();
+		$should_check_vulnerabilities = $this->getWpVulnApiToken();
 		$vulnerable = false;
 
 		foreach( $all_plugins as $plugin_path => $data ) {
@@ -87,7 +89,7 @@ class Plugins extends Checkimplementation {
 	protected function getPluginVulnerability( $plugin_slug )
 	{
 		// Get the vulnerability API token from the platform
-		$wpvulndb_api_token = $this->getWpScanApiToken();
+		$wpvulndb_api_token = $this->getWpVulnApiToken();
 
 		// Fail silently if there is no API token.
 		if( false === $wpvulndb_api_token || empty( $wpvulndb_api_token ) ) {
@@ -128,27 +130,6 @@ class Plugins extends Checkimplementation {
 
 		// Return the requested plugin vulnerability info
 		return $result[$plugin_slug];
-	}
-
-
-	protected function getWpScanApiToken() {
-		if ( defined( 'WPSCAN_API_TOKEN' ) ) {
-			// Don't use WPSCAN if PANTHEON_WPSCAN_ENVIRONMENTS have not been specified.
-			if( ! defined( 'PANTHEON_WPSCAN_ENVIRONMENTS' ) ) {
-				return false;
-			}
-
-			$environments = ( ! is_array( PANTHEON_WPSCAN_ENVIRONMENTS ) ) ? explode( ',', PANTHEON_WPSCAN_ENVIRONMENTS ) : PANTHEON_WPSCAN_ENVIRONMENTS;
-
-			// Only run WPSCAN on the specified environments unless it's been configured to run on all (*).
-			if ( in_array( getenv( 'PANTHEON_ENVIRONMENT' ), $environments, true ) || in_array( '*', $environments, true ) ) {
-				return WPSCAN_API_TOKEN;
-			}
-		}
-
-		// TODO: Replace this PANTHEON_WPVULNDB_API_TOKEN with a new Patchstack API token.
-		// return getenv( 'PANTHEON_WPVULNDB_API_TOKEN' );
-		return false;
 	}
 
 	/**
@@ -200,7 +181,7 @@ class Plugins extends Checkimplementation {
 		$plugin_message = __( 'You should update all out-of-date plugins' );
 		$vuln_message = __( 'Update plugins to fix vulnerabilities' );
 		$no_plugins_message = __( 'No plugins found' );
-		$should_check_vulnerabilities = $this->getWpScanApiToken();
+		$should_check_vulnerabilities = Common\get_wp_vuln_api_token();
 
 		if (!empty($this->alerts)) {
 			$headers = array(

--- a/php/pantheon/checks/plugins.php
+++ b/php/pantheon/checks/plugins.php
@@ -43,7 +43,8 @@ class Plugins extends Checkimplementation {
 				$slug = substr($plugin_path, 0, stripos($plugin_path,'/'));
 			}
 
-			$vulnerable = $this->is_vulnerable($slug, $data['Version']);
+			// Todo: Commented out pending Patchstack integration.
+			// $vulnerable = $this->is_vulnerable($slug, $data['Version']);
 
 			$needs_update = 0;
 			$available = '-';
@@ -51,18 +52,19 @@ class Plugins extends Checkimplementation {
 				$needs_update = 1;
 				$available = $update[$plugin_path]->update->new_version;
 			}
-			if ( false === $vulnerable ) {
-				$vulnerable = "None";
-			} else {
-				$vulnerable = sprintf('<a href="https://wpscan.com/plugins/%s" target="_blank" >more info</a>', $slug );
-			}
+			// Todo: Commented out pending Patchstack integration.
+			// if ( false === $vulnerable ) {
+			// 	$vulnerable = "None";
+			// } else {
+			// 	$vulnerable = sprintf('<a href="https://wpscan.com/plugins/%s" target="_blank" >more info</a>', $slug );
+			// }
 
 			$report[$slug] = array(
 				'slug' => $slug,
 				'installed' => (string) $data['Version'],
 				'available' => (string) $available,
 				'needs_update' => (string) $needs_update,
-				'vulnerable'  => $vulnerable,
+				// 'vulnerable'  => $vulnerable,
 			);
 		}
 		$this->alerts = $report;

--- a/php/pantheon/checks/plugins.php
+++ b/php/pantheon/checks/plugins.php
@@ -232,11 +232,13 @@ class Plugins extends Checkimplementation {
 				$rows[] = array('class'=>$class, 'data' => $alert);
 			}
 
+			$updates_message = $count_update === 1 ? __( 'Found one plugin needing updates' ) : sprintf( _n( 'Found %d plugin needing updates', 'Found %d plugins needing updates', $count_update ), $count_update );
 			$result_message = ! $should_check_vulnerabilities ?
 				// Not checking vulnerabilities message.
-				sprintf( __( 'Found %s needing updates ...' ), _n( 'one plugin', '%d plugins', $count_update ) ) :
+				$updates_message . ' ...':
 				// Checking vulnerabilities message.
-				sprintf( __( 'Found %s needing updates and %s known vulnerabilities ...' ), _n( 'one plugin', '%d plugins', $count_update ), _n( 'one plugin', '%d plugins', $count_vuln ) );
+				$updates_message . ' ' .
+				( $count_vuln === 1 ? __( 'Also found one plugin with known vulnerabilities ...' ) : sprintf( _n( 'Also found %d plugin with known vulnerabilities ...', 'Also found %d plugins with known vulnerabilities ...', $count_vuln ), $count_vuln ) );
 			$rendered = PHP_EOL;
 			$rendered .= "$result_message \n" . PHP_EOL;
 			$rendered .= View::make('table', array('headers'=>$headers,'rows'=>$rows));

--- a/php/pantheon/checks/plugins.php
+++ b/php/pantheon/checks/plugins.php
@@ -73,8 +73,8 @@ class Plugins extends Checkimplementation {
 	/**
 	 * Checks the plugin slug against the vulnerability db
 	 * @param $plugin_slug string (required) string representing the plugin slug
-	 *
 	 * @return array containing vulnerability info or false
+	 * @todo Refactor to use Patchstack API.
 	 */
 	protected function getPluginVulnerability( $plugin_slug )
 	{

--- a/php/pantheon/checks/plugins.php
+++ b/php/pantheon/checks/plugins.php
@@ -210,10 +210,10 @@ class Plugins extends Checkimplementation {
 					$class = 'warning';
 					$count_update++;
 				}
-				if ('None' != $alert['vulnerable']) {
-					$class = 'error';
-					$count_vuln++;
-				}
+				// if ('None' != $alert['vulnerable']) {
+				// 	$class = 'error';
+				// 	$count_vuln++;
+				// }
 				$rows[] = array('class'=>$class, 'data' => $alert);
 			}
 

--- a/php/pantheon/checks/plugins.php
+++ b/php/pantheon/checks/plugins.php
@@ -217,6 +217,8 @@ class Plugins extends Checkimplementation {
 				$rows[] = array('class'=>$class, 'data' => $alert);
 			}
 
+			// Todo: Previous message included %d known vulnerabilities linked to $count_vuln.
+			$result_message = sprintf( __( 'Found %s needing updates ...' ), _n( 'one plugin', '%d plugins', $count_update ) );
 			$rendered = PHP_EOL;
 			$rendered .= "$result_message \n" . PHP_EOL;
 			$rendered .= View::make('table', array('headers'=>$headers,'rows'=>$rows));

--- a/php/pantheon/checks/plugins.php
+++ b/php/pantheon/checks/plugins.php
@@ -39,7 +39,7 @@ class Plugins extends Checkimplementation {
 		$all_plugins = Utils::sanitize_data( get_plugins() );
 		$update = Utils::sanitize_data( get_plugin_updates() );
 		$report = array();
-		$should_check_vulnerabilities = $this->getWpVulnApiToken();
+		$should_check_vulnerabilities = Common\get_wp_vuln_api_token();
 		$vulnerable = false;
 
 		foreach( $all_plugins as $plugin_path => $data ) {
@@ -89,7 +89,7 @@ class Plugins extends Checkimplementation {
 	protected function getPluginVulnerability( $plugin_slug )
 	{
 		// Get the vulnerability API token from the platform
-		$wpvulndb_api_token = $this->getWpVulnApiToken();
+		$wpvulndb_api_token = Common\get_wp_vuln_api_token();
 
 		// Fail silently if there is no API token.
 		if( false === $wpvulndb_api_token || empty( $wpvulndb_api_token ) ) {

--- a/php/pantheon/checks/plugins.php
+++ b/php/pantheon/checks/plugins.php
@@ -122,28 +122,23 @@ class Plugins extends Checkimplementation {
 
 
 	protected function getWpScanApiToken() {
-		if( !defined( 'PANTHEON_WPSCAN_ENVIRONMENTS' ) ) {
-			return false;
+		if ( defined( 'WPSCAN_API_TOKEN' ) ) {
+			// Don't use WPSCAN if PANTHEON_WPSCAN_ENVIRONMENTS have not been specified.
+			if( ! defined( 'PANTHEON_WPSCAN_ENVIRONMENTS' ) ) {
+				return false;
+			}
+
+			$environments = ( ! is_array( PANTHEON_WPSCAN_ENVIRONMENTS ) ) ? explode( ',', PANTHEON_WPSCAN_ENVIRONMENTS ) : PANTHEON_WPSCAN_ENVIRONMENTS;
+
+			// Only run WPSCAN on the specified environments unless it's been configured to run on all (*).
+			if ( in_array( getenv( 'PANTHEON_ENVIRONMENT' ), $environments, true ) || in_array( '*', $environments, true ) ) {
+				return WPSCAN_API_TOKEN;
+			}
 		}
 
-		if ( ! is_array( PANTHEON_WPSCAN_ENVIRONMENTS ) ) {
-			$environments = explode( ',', PANTHEON_WPSCAN_ENVIRONMENTS );
-		} else {
-			$environments = PANTHEON_WPSCAN_ENVIRONMENTS;
-		}
-
-		if(
-			!in_array( getenv( 'PANTHEON_ENVIRONMENT' ), $environments )
-			&& !in_array( '*', $environments )
-		) {
-			return false;
-		}
-
-		if( defined( 'WPSCAN_API_TOKEN' ) ) {
-			return WPSCAN_API_TOKEN;
-		}
-
-		return getenv( 'PANTHEON_WPVULNDB_API_TOKEN' );
+		// TODO: Replace this PANTHEON_WPVULNDB_API_TOKEN with a new Patchstack API token.
+		// return getenv( 'PANTHEON_WPVULNDB_API_TOKEN' );
+		return false;
 	}
 
 	/**

--- a/php/pantheon/checks/plugins.php
+++ b/php/pantheon/checks/plugins.php
@@ -57,7 +57,7 @@ class Plugins extends Checkimplementation {
 				$available = $update[$plugin_path]->update->new_version;
 			}
 
-			if ( $should_check_vulnerabilities && isset( $vulnerable ) ) {
+			if ( $should_check_vulnerabilities && $vulnerable ) {
 				// Todo: Replace this URL with a Patchstack URL
 				$vulnerable = sprintf('<a href="https://wpscan.com/plugins/%s" target="_blank" >more info</a>', $slug );
 			} elseif ( $should_check_vulnerabilities ) {

--- a/php/pantheon/checks/plugins.php
+++ b/php/pantheon/checks/plugins.php
@@ -65,7 +65,6 @@ class Plugins extends Checkimplementation {
 			// If we're checking for vulnerabilities, do stuff.
 			if ( $should_check_vulnerabilities ) {
 				$vulnerable = $this->is_vulnerable($slug, $data['Version']);
-				$report[ $slug ]['vulnerable'] = $vulnerable;
 
 				if ( $vulnerable ) {
 					// Todo: Replace this URL with a Patchstack URL
@@ -73,6 +72,8 @@ class Plugins extends Checkimplementation {
 				} else {
 					$vulnerable = "None";
 				}
+
+				$report[ $slug ]['vulnerable'] = $vulnerable;
 			}
 		}
 		$this->alerts = $report;

--- a/php/pantheon/checks/plugins.php
+++ b/php/pantheon/checks/plugins.php
@@ -189,13 +189,17 @@ class Plugins extends Checkimplementation {
 	}
 
 	public function message(Messenger $messenger) {
+		$plugin_message = __( 'You should update all out-of-date plugins' );
+		$vuln_message = __( 'Update plugins to fix vulnerabilities' );
+		$no_plugins_message = __( 'No plugins found' );
+
 		if (!empty($this->alerts)) {
 			$headers = array(
-				'slug'=>"Plugin",
-				'installed'=>"Current",
-				'available' => "Available",
-				'needs_update'=>"Needs Update",
-				'vulnerable'=>"Vulnerabilities"
+				'slug'=> __( 'Plugin' ),
+				'installed'=> __( 'Current' ),
+				'available' => __( 'Available' ),
+				'needs_update'=> __( 'Needs Update' ),
+				// 'vulnerable'=> __( ' Vulnerabilities' ),
 			);
 			$rows = array();
 			$count_update = 0;
@@ -214,21 +218,21 @@ class Plugins extends Checkimplementation {
 			}
 
 			$rendered = PHP_EOL;
-			$rendered .= sprintf("Found %d plugins needing updates and %d known vulnerabilities ... \n".PHP_EOL, $count_update, $count_vuln);
+			$rendered .= "$result_message \n" . PHP_EOL;
 			$rendered .= View::make('table', array('headers'=>$headers,'rows'=>$rows));
 
 			$this->result .= $rendered;
 			if ($count_update > 0) {
 				$this->score = 1;
-				$this->action = "You should update all out-of-date plugins";
+				$this->action = $plugin_message;
 			}
 
 			if ($count_vuln > 0) {
 				$this->score = 2;
-				$this->action = "Update plugins to fix vulnerabilities";
+				$this->action = $vuln_message;
 			}
 		} else {
-			$this->result .= "No plugins found.";
+			$this->result .= $no_plugins_message;
 		}
 		$messenger->addMessage(get_object_vars($this));
 	}

--- a/php/pantheon/checks/plugins.php
+++ b/php/pantheon/checks/plugins.php
@@ -48,22 +48,11 @@ class Plugins extends Checkimplementation {
 				$slug = substr($plugin_path, 0, stripos($plugin_path,'/'));
 			}
 
-			if ( $should_check_vulnerabilities ) {
-				$vulnerable = $this->is_vulnerable($slug, $data['Version']);
-			}
-
 			$needs_update = 0;
 			$available = '-';
 			if (isset($update[$plugin_path])) {
 				$needs_update = 1;
 				$available = $update[$plugin_path]->update->new_version;
-			}
-
-			if ( $should_check_vulnerabilities && $vulnerable ) {
-				// Todo: Replace this URL with a Patchstack URL
-				$vulnerable = sprintf('<a href="https://wpscan.com/plugins/%s" target="_blank" >more info</a>', $slug );
-			} elseif ( $should_check_vulnerabilities ) {
-				$vulnerable = "None";
 			}
 
 			$report[ $slug ] = array(
@@ -73,8 +62,17 @@ class Plugins extends Checkimplementation {
 				'needs_update' => (string) $needs_update,
 			);
 
+			// If we're checking for vulnerabilities, do stuff.
 			if ( $should_check_vulnerabilities ) {
+				$vulnerable = $this->is_vulnerable($slug, $data['Version']);
 				$report[ $slug ]['vulnerable'] = $vulnerable;
+
+				if ( $vulnerable ) {
+					// Todo: Replace this URL with a Patchstack URL
+					$vulnerable = sprintf('<a href="https://wpscan.com/plugins/%s" target="_blank" >more info</a>', $slug );
+				} else {
+					$vulnerable = "None";
+				}
 			}
 		}
 		$this->alerts = $report;
@@ -198,6 +196,7 @@ class Plugins extends Checkimplementation {
 			$rows = array();
 			$count_update = 0;
 			$count_vuln = 0;
+
 			foreach( $this->alerts as $alert ) {
 				$class = 'ok';
 				if ($alert['needs_update']) {

--- a/php/pantheon/checks/themes.php
+++ b/php/pantheon/checks/themes.php
@@ -12,6 +12,8 @@ class Themes extends Checkimplementation {
 	public $alerts = array();
 
 	public function __construct($check_all_themes) {
+		require_once __DIR__ . '/namespace.php';
+
 		$this->check_all_themes = $check_all_themes;
 	}
 
@@ -38,7 +40,7 @@ class Themes extends Checkimplementation {
 		$all_themes = Utils::sanitize_data( wp_get_themes() );
 		$update = Utils::sanitize_data( get_theme_updates() );
 		$report = array();
-		$should_check_vulnerabilities = $this->getWpVulnApiToken();
+		$should_check_vulnerabilities = Common\get_wp_vuln_api_token();
 		$vulnerable = false;
 
 		foreach( $all_themes as $theme_path => $data ) {
@@ -99,7 +101,7 @@ class Themes extends Checkimplementation {
 		if ( defined( 'WPSCAN_API_TOKEN' ) ) {
 			// Don't use WPSCAN if PANTHEON_WPSCAN_ENVIRONMENTS have not been specified.
 			if( ! defined( 'PANTHEON_WPSCAN_ENVIRONMENTS' ) ) {
-				return false;
+				return '';
 			}
 
 			$environments = ( ! is_array( PANTHEON_WPSCAN_ENVIRONMENTS ) ) ? explode( ',', PANTHEON_WPSCAN_ENVIRONMENTS ) : PANTHEON_WPSCAN_ENVIRONMENTS;
@@ -112,7 +114,7 @@ class Themes extends Checkimplementation {
 
 		// TODO: Replace this PANTHEON_WPVULNDB_API_TOKEN with a new Patchstack API token.
 		// return getenv( 'PANTHEON_WPVULNDB_API_TOKEN' );
-		return false;
+		return '';
 	}
 
 	/**
@@ -124,7 +126,7 @@ class Themes extends Checkimplementation {
 	 * @todo Refactor this to use the Patchstack API
 	 */
 	protected function getThemeVulnerability($theme_slug ) {
-		$wpvulndb_api_token = $this->getWpVulnApiToken();
+		$wpvulndb_api_token = Common\get_wp_vuln_api_token();
 
 		// Fail silently if there is no API token.
 		if( false === $wpvulndb_api_token || empty( $wpvulndb_api_token ) ) {
@@ -214,7 +216,7 @@ class Themes extends Checkimplementation {
 
 	public function message(Messenger $messenger) {
 		if (!empty($this->alerts)) {
-			$should_check_vulnerabilities = $this->getWpVulnApiToken();
+			$should_check_vulnerabilities = Common\get_wp_vuln_api_token();
 			$theme_message = __( 'You should update all out-of-date themes' );
 			$vuln_message = __( 'Update themes to fix vulnerabilities' );
 			$no_themes_message = __( 'No themes found' );

--- a/php/pantheon/checks/themes.php
+++ b/php/pantheon/checks/themes.php
@@ -92,34 +92,6 @@ class Themes extends Checkimplementation {
 	}
 
 	/**
-	 * Get a WordPress vulnerability API token if one is defined and we're in the right environment.
-	 * Copied from wp_launch_check/php/pantheon/checks/plugins.php
-	 * Uses the WPSCAN_API_TOKEN constant if defined.
-	 *
-	 * @return string|false
-	 * @todo Replace this with a Patchstack API token.
-	 */
-	protected function getWpVulnApiToken() {
-		if ( defined( 'WPSCAN_API_TOKEN' ) ) {
-			// Don't use WPSCAN if PANTHEON_WPSCAN_ENVIRONMENTS have not been specified.
-			if( ! defined( 'PANTHEON_WPSCAN_ENVIRONMENTS' ) ) {
-				return '';
-			}
-
-			$environments = ( ! is_array( PANTHEON_WPSCAN_ENVIRONMENTS ) ) ? explode( ',', PANTHEON_WPSCAN_ENVIRONMENTS ) : PANTHEON_WPSCAN_ENVIRONMENTS;
-
-			// Only run WPSCAN on the specified environments unless it's been configured to run on all (*).
-			if ( in_array( getenv( 'PANTHEON_ENVIRONMENT' ), $environments, true ) || in_array( '*', $environments, true ) ) {
-				return WPSCAN_API_TOKEN;
-			}
-		}
-
-		// TODO: Replace this PANTHEON_WPVULNDB_API_TOKEN with a new Patchstack API token.
-		// return getenv( 'PANTHEON_WPVULNDB_API_TOKEN' );
-		return '';
-	}
-
-	/**
 	 * Checks the theme slug against the vulnerability db
 	 * @param $theme_slug string (required) string representing the theme slug
 	 *

--- a/php/pantheon/checks/themes.php
+++ b/php/pantheon/checks/themes.php
@@ -80,6 +80,34 @@ class Themes extends Checkimplementation {
 	}
 
 	/**
+	 * Get a WordPress vulnerability API token if one is defined and we're in the right environment.
+	 * Copied from wp_launch_check/php/pantheon/checks/plugins.php
+	 * Uses the WPSCAN_API_TOKEN constant if defined.
+	 *
+	 * @return string|false
+	 * @todo Replace this with a Patchstack API token.
+	 */
+	protected function getWpVulnApiToken() {
+		if ( defined( 'WPSCAN_API_TOKEN' ) ) {
+			// Don't use WPSCAN if PANTHEON_WPSCAN_ENVIRONMENTS have not been specified.
+			if( ! defined( 'PANTHEON_WPSCAN_ENVIRONMENTS' ) ) {
+				return false;
+			}
+
+			$environments = ( ! is_array( PANTHEON_WPSCAN_ENVIRONMENTS ) ) ? explode( ',', PANTHEON_WPSCAN_ENVIRONMENTS ) : PANTHEON_WPSCAN_ENVIRONMENTS;
+
+			// Only run WPSCAN on the specified environments unless it's been configured to run on all (*).
+			if ( in_array( getenv( 'PANTHEON_ENVIRONMENT' ), $environments, true ) || in_array( '*', $environments, true ) ) {
+				return WPSCAN_API_TOKEN;
+			}
+		}
+
+		// TODO: Replace this PANTHEON_WPVULNDB_API_TOKEN with a new Patchstack API token.
+		// return getenv( 'PANTHEON_WPVULNDB_API_TOKEN' );
+		return false;
+	}
+
+	/**
 	 * Checks the theme slug against the vulnerability db
 	 * @param $theme_slug string (required) string representing the theme slug
 	 *

--- a/php/pantheon/checks/themes.php
+++ b/php/pantheon/checks/themes.php
@@ -77,7 +77,6 @@ class Themes extends Checkimplementation {
 			// If we're checking for vulnerabilities, do stuff.
 			if ( $should_check_vulnerabilities ) {
 				$vulnerable = $this->is_vulnerable($slug, $version);
-				$report[ $slug ]['vulnerable'] = $vulnerable;
 
 				if ( $vulnerable ) {
 					// Todo: Replace this link with one to Patchstack.
@@ -85,6 +84,8 @@ class Themes extends Checkimplementation {
 				} else {
 					$vulnerable = "None";
 				}
+
+				$report[ $slug ]['vulnerable'] = $vulnerable;
 			}
 		}
 		$this->alerts = $report;

--- a/php/pantheon/checks/themes.php
+++ b/php/pantheon/checks/themes.php
@@ -59,20 +59,12 @@ class Themes extends Checkimplementation {
 
 			$data = wp_get_theme($slug);
 			$version = $data->version;
-			if ( $should_check_vulnerabilities ) {
-				$vulnerable = $this->is_vulnerable($slug, $version);
-			}
-
 			$needs_update = 0;
 			$available = '-';
+
 			if (isset($update[$theme_path])) {
 				$needs_update = 1;
 				$available = $update[$slug]->update["new_version"];
-			}
-			if ( $should_check_vulnerabilities && $vulnerable ) {
-				$vulnerable = sprintf('<a href="https://wpscan.com/themes/%s" target="_blank" >more info</a>', $slug );
-			} elseif ( $should_check_vulnerabilities ) {
-				$vulnerable = "None";
 			}
 
 			$report[$slug] = array(
@@ -82,8 +74,17 @@ class Themes extends Checkimplementation {
 				'needs_update' => (string) $needs_update,
 			);
 
+			// If we're checking for vulnerabilities, do stuff.
 			if ( $should_check_vulnerabilities ) {
+				$vulnerable = $this->is_vulnerable($slug, $version);
 				$report[ $slug ]['vulnerable'] = $vulnerable;
+
+				if ( $vulnerable ) {
+					// Todo: Replace this link with one to Patchstack.
+					$vulnerable = sprintf('<a href="https://wpscan.com/themes/%s" target="_blank" >more info</a>', $slug );
+				} else {
+					$vulnerable = "None";
+				}
 			}
 		}
 		$this->alerts = $report;


### PR DESCRIPTION
Pending integrating with a new vulnerability scan API, we need to remove the vulnerability column unless a WPSCAN_API_TOKEN is explicitly passed.