### PR TITLE
remove 7.2 & 7.3 php release tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,6 @@ jobs:
   validate:
     name: "Run validation test suite"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-versions: ["7.2", "7.3", "7.4"]
     env:
       # GITHUB_CONTEXT: ${{ toJson(github) }}
       PANTHEON_WPVULNDB_API_TOKEN: ${{ secrets.PANTHEON_WPVULNDB_API_TOKEN }}
@@ -42,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: 7.4
           ini-values: post_max_size=256M, max_execution_time=120
 
       - name: Get Composer Cache Directory


### PR DESCRIPTION
These were removed from the validate.yml step but not from release.yml. The older PHP checks aren't really serving us and just making deploys take longer & using more resources.