### PR TITLE
Bump WP Core version to 6.3 and 4.6.26

### DIFF
--- a/features/general.feature
+++ b/features/general.feature
@@ -49,7 +49,7 @@ Feature: General tests of WP Launch Check
     # This check is here to remind us to update versions when new releases are available.
     Then STDOUT should contain:
       """
-      6.2
+      6.3
       """
 
     When I run `wp launchcheck general`
@@ -60,7 +60,7 @@ Feature: General tests of WP Launch Check
 
   Scenario: WordPress has a new minor version but no new major version
     Given a WP install
-    And I run `wp core download --version=6.2 --force`
+    And I run `wp core download --version=6.3 --force`
     And I run `wp theme activate twentytwentytwo`
 
     When I run `wp launchcheck general`
@@ -71,7 +71,7 @@ Feature: General tests of WP Launch Check
 
   Scenario: WordPress has a new major version but no new minor version
     Given a WP install
-    And I run `wp core download --version=5.6.11 --force`
+    And I run `wp core download --version=4.6.26 --force`
     And I run `wp theme activate twentytwenty`
 
     When I run `wp launchcheck general`


### PR DESCRIPTION
It's intentional that the version(s) being updated to, 6.3 and 4.6.26, are not the latest version(s) available.