### PR TITLE
use new secret name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,13 +104,13 @@ jobs:
         id: changelog
         uses: metcalfc/changelog-generator@v1.0.0
         with:
-          myToken: ${{ secrets.GITHUB_TOKEN }}
+          myToken: ${{ secrets.ACCESS_TOKEN }}
 
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
@@ -123,7 +123,7 @@ jobs:
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./wp_launch_check.phar


### PR DESCRIPTION
There was no token named `GITHUB_TOKEN` in the repository which was causing the deploy step to fail. 
On adding the token back, GitHub blocked access to using the `GITHUB_` prefix in repository secrets. This updates the secret name to match the new secret.

Of note: the [actions/create-release](https://github.com/actions/create-release) action we are using is no longer supported by GitHub. There is an open issue (https://github.com/actions/create-release/issues/103) describing this same issue and this resolution is similar to [one of the fixes](https://github.com/Drakkar-Software/OctoBot/pull/1613/files) linked to that issue.