### PR TITLE
Bump WP Core version to 6.5 and 6.4.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -93,7 +93,7 @@ jobs:
     needs: [validate]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download Phar
         uses: actions/download-artifact@v2

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/features/bootstrap/utils.php
+++ b/features/bootstrap/utils.php
@@ -706,13 +706,18 @@ function get_temp_dir() {
  *
  * @access public
  * @category System
- *
+ * @throws Exception If the version check API fails to respond.
  * @return string
  */
 function get_wp_version() {
 	// Fetch the latest WordPress version info from the WordPress.org API
 	$url = 'https://api.wordpress.org/core/version-check/1.7/';
-	$json = file_get_contents($url);
+	$context = stream_context_create(['http' => ['timeout' => 5]]);
+	$json = file_get_contents($url, false, $context);
+	if ($json === false) {
+		throw new \Exception('Failed to fetch the latest WordPress version.');
+	}
+
 	$data = json_decode($json, true);
 
 	// Extract the latest version number

--- a/features/bootstrap/utils.php
+++ b/features/bootstrap/utils.php
@@ -700,3 +700,22 @@ function get_temp_dir() {
 
 	return $trailingslashit( $temp );
 }
+
+/**
+ * Get the latest WordPress version from the version check API endpoint.
+ *
+ * @access public
+ * @category System
+ *
+ * @return string
+ */
+function get_wp_version() {
+	// Fetch the latest WordPress version info from the WordPress.org API
+	$url = 'https://api.wordpress.org/core/version-check/1.7/';
+	$json = file_get_contents($url);
+	$data = json_decode($json, true);
+
+	// Extract the latest version number
+	$latestVersion = $data['offers'][0]['current'];
+	return trim($latestVersion);
+}

--- a/features/general.feature
+++ b/features/general.feature
@@ -49,7 +49,7 @@ Feature: General tests of WP Launch Check
     # This check is here to remind us to update versions when new releases are available.
     Then STDOUT should contain:
       """
-      6.5.3
+      6.5
       """
 
     When I run `wp launchcheck general`

--- a/features/general.feature
+++ b/features/general.feature
@@ -61,7 +61,6 @@ Feature: General tests of WP Launch Check
   Scenario: WordPress has a new minor version but no new major version
     Given a WP install
     And I run `wp core download --version=6.5 --force`
-		And I run `latestVersion=$(wp core check-update --field=version) && currentVersion=$(wp core version) && [ "$latestVersion" == "$currentVersion" ]; then; echo "There is no new minor version available"; exit 0; fi`
     And I run `wp theme activate twentytwentytwo`
 		And the current WP version is not the latest
 

--- a/features/general.feature
+++ b/features/general.feature
@@ -62,6 +62,7 @@ Feature: General tests of WP Launch Check
     Given a WP install
     And I run `wp core download --version=6.5 --force`
     And I run `wp theme activate twentytwentytwo`
+		And the current WP version is not the latest
 
     When I run `wp launchcheck general`
     Then STDOUT should contain:

--- a/features/general.feature
+++ b/features/general.feature
@@ -61,6 +61,7 @@ Feature: General tests of WP Launch Check
   Scenario: WordPress has a new minor version but no new major version
     Given a WP install
     And I run `wp core download --version=6.5 --force`
+		And I run `latestVersion=$(wp core check-update --field=version) && currentVersion=$(wp core version) && [ "$latestVersion" == "$currentVersion" ]; then; echo "There is no new minor version available"; exit 0; fi`
     And I run `wp theme activate twentytwentytwo`
 		And the current WP version is not the latest
 

--- a/features/general.feature
+++ b/features/general.feature
@@ -62,7 +62,7 @@ Feature: General tests of WP Launch Check
     Given a WP install
     And I run `wp core download --version=6.5 --force`
     And I run `wp theme activate twentytwentytwo`
-		And the current WP version is not the latest
+    And the current WP version is not the latest
 
     When I run `wp launchcheck general`
     Then STDOUT should contain:

--- a/features/general.feature
+++ b/features/general.feature
@@ -49,7 +49,7 @@ Feature: General tests of WP Launch Check
     # This check is here to remind us to update versions when new releases are available.
     Then STDOUT should contain:
       """
-      6.4.3
+      6.5.3
       """
 
     When I run `wp launchcheck general`
@@ -60,7 +60,7 @@ Feature: General tests of WP Launch Check
 
   Scenario: WordPress has a new minor version but no new major version
     Given a WP install
-    And I run `wp core download --version=6.4 --force`
+    And I run `wp core download --version=6.5 --force`
     And I run `wp theme activate twentytwentytwo`
 
     When I run `wp launchcheck general`
@@ -71,7 +71,7 @@ Feature: General tests of WP Launch Check
 
   Scenario: WordPress has a new major version but no new minor version
     Given a WP install
-    And I run `wp core download --version=6.3.3 --force`
+    And I run `wp core download --version=6.4.3 --force`
     And I run `wp theme activate twentytwentytwo`
 
     When I run `wp launchcheck general`

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -158,10 +158,14 @@ $steps->Given('/^a misconfigured WP_CONTENT_DIR constant directory$/',
 
 $steps->Given('/^the current WP version is not the latest$/', function ($world) {
 	// Use wp-cli to get the currently installed WordPress version.
-	$currentVersion = shell_exec('wp core version');
+	$currentVersion = $world->proc('wp core version', [])
+		->run_check()
+		->stdout();
 
 	// Use wp-cli to get the latest WordPress version available.
-	$latestVersion = shell_exec('wp core check-update --field=version');
+	$latestVersion = $world->proc('wp core check-update --field=version', [])
+		->run_check()
+		->stdout();
 
 	// Normalize versions (remove new lines).
 	$currentVersion = trim($currentVersion);

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -155,3 +155,20 @@ $steps->Given('/^a misconfigured WP_CONTENT_DIR constant directory$/',
 		file_put_contents( $wp_config_path, $wp_config_code );
 	}
 );
+
+$steps->Given('/^the current WP version is not the latest$/', function ($world) {
+	// Use wp-cli to get the currently installed WordPress version.
+	$currentVersion = shell_exec('wp core version');
+
+	// Use wp-cli to get the latest WordPress version available.
+	$latestVersion = shell_exec('wp core check-update --field=version');
+
+	// Normalize versions (remove new lines).
+	$currentVersion = trim($currentVersion);
+	$latestVersion = trim($latestVersion);
+
+	// If there's no update available or the current version is the latest, throw an exception to skip the test.
+	if (empty($latestVersion) || $currentVersion === $latestVersion) {
+		throw new Exception("The current WordPress version is the latest. Test skipped.");
+	}
+});

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -158,14 +158,14 @@ $steps->Given('/^a misconfigured WP_CONTENT_DIR constant directory$/',
 
 $steps->Given('/^the current WP version is not the latest$/', function ($world) {
 	// Use wp-cli to get the currently installed WordPress version.
-	$currentVersion = $world->proc('wp core version');
+	$currentVersion = $world->proc('wp core version')->run;
 
 	// Use wp-cli to get the latest WordPress version available.
-	$latestVersion = $world->proc('wp core check-update --field=version');
+	$latestVersion = $world->proc('wp core check-update --field=version')->run;
 
 	// Normalize versions (remove new lines).
-	$currentVersion = trim($currentVersion['stdout']);
-	$latestVersion = trim($latestVersion['stdout']);
+	$currentVersion = trim($currentVersion->stdout);
+	$latestVersion = trim($latestVersion->stdout);
 
 	// If there's no update available or the current version is the latest, throw an exception to skip the test.
 	if (empty($latestVersion) || $currentVersion === $latestVersion) {

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -164,8 +164,8 @@ $steps->Given('/^the current WP version is not the latest$/', function ($world) 
 	$latestVersion = $world->proc('wp core check-update --field=version');
 
 	// Normalize versions (remove new lines).
-	$currentVersion = trim($currentVersion);
-	$latestVersion = trim($latestVersion);
+	$currentVersion = trim($currentVersion->stdout);
+	$latestVersion = trim($latestVersion->stdout);
 
 	// If there's no update available or the current version is the latest, throw an exception to skip the test.
 	if (empty($latestVersion) || $currentVersion === $latestVersion) {

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -4,6 +4,8 @@ use Behat\Gherkin\Node\PyStringNode,
     Behat\Gherkin\Node\TableNode,
     WP_CLI\Process;
 
+use function WP_CLI\Utils\get_wp_version;
+
 $steps->Given( '/^an empty directory$/',
 	function ( $world ) {
 		$world->create_run_dir();
@@ -157,20 +159,12 @@ $steps->Given('/^a misconfigured WP_CONTENT_DIR constant directory$/',
 );
 
 $steps->Given('/^the current WP version is not the latest$/', function ($world) {
-	// Fetch the latest WordPress version info from the WordPress.org API
-	$url = 'https://api.wordpress.org/core/version-check/1.7/';
-	$json = file_get_contents($url);
-	$data = json_decode($json, true);
-
-	// Extract the latest version number
-	$latestVersion = $data['offers'][0]['current'];
-
 	// Use wp-cli to get the currently installed WordPress version.
 	$currentVersion = $world->proc('wp core version')->run();
 
 	// Normalize versions (remove new lines).
 	$currentVersion = trim($currentVersion->stdout);
-	$latestVersion = trim($latestVersion);
+	$latestVersion = get_wp_version();
 
 	// If there's no update available or the current version is the latest, throw an exception to skip the test.
 	if (empty($latestVersion) || $currentVersion === $latestVersion) {

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -164,8 +164,8 @@ $steps->Given('/^the current WP version is not the latest$/', function ($world) 
 	$latestVersion = $world->proc('wp core check-update --field=version');
 
 	// Normalize versions (remove new lines).
-	$currentVersion = trim($currentVersion->stdout);
-	$latestVersion = trim($latestVersion->stdout);
+	$currentVersion = trim($currentVersion['stdout']);
+	$latestVersion = trim($latestVersion['stdout']);
 
 	// If there's no update available or the current version is the latest, throw an exception to skip the test.
 	if (empty($latestVersion) || $currentVersion === $latestVersion) {

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -170,6 +170,7 @@ $steps->Given('/^the current WP version is not the latest$/', function ($world) 
 	// If there's no update available or the current version is the latest, throw an exception to skip the test.
 	if (empty($latestVersion) || $currentVersion === $latestVersion) {
 		$world->isLatestWPVersion = true;
+		return;
 	}
 
 	$world->isLatestWPVersion = false;

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -170,7 +170,6 @@ $steps->Given('/^the current WP version is not the latest$/', function ($world) 
 	// If there's no update available or the current version is the latest, throw an exception to skip the test.
 	if (empty($latestVersion) || $currentVersion === $latestVersion) {
 		$world->isLatestWPVersion = true;
-		throw new Exception("The current WordPress version is the latest. Test skipped.");
 	}
 
 	$world->isLatestWPVersion = false;

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -158,10 +158,10 @@ $steps->Given('/^a misconfigured WP_CONTENT_DIR constant directory$/',
 
 $steps->Given('/^the current WP version is not the latest$/', function ($world) {
 	// Use wp-cli to get the currently installed WordPress version.
-	$currentVersion = $world->proc('wp core version')->run;
+	$currentVersion = $world->proc('wp core version')->run();
 
 	// Use wp-cli to get the latest WordPress version available.
-	$latestVersion = $world->proc('wp core check-update --field=version')->run;
+	$latestVersion = $world->proc('wp core check-update --field=version')->run();
 
 	// Normalize versions (remove new lines).
 	$currentVersion = trim($currentVersion->stdout);

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -157,15 +157,20 @@ $steps->Given('/^a misconfigured WP_CONTENT_DIR constant directory$/',
 );
 
 $steps->Given('/^the current WP version is not the latest$/', function ($world) {
+	// Fetch the latest WordPress version info from the WordPress.org API
+	$url = 'https://api.wordpress.org/core/version-check/1.7/';
+	$json = file_get_contents($url);
+	$data = json_decode($json, true);
+
+	// Extract the latest version number
+	$latestVersion = $data['offers'][0]['current'];
+
 	// Use wp-cli to get the currently installed WordPress version.
 	$currentVersion = $world->proc('wp core version')->run();
 
-	// Use wp-cli to get the latest WordPress version available.
-	$latestVersion = $world->proc('wp core check-update --field=version')->run();
-
 	// Normalize versions (remove new lines).
 	$currentVersion = trim($currentVersion->stdout);
-	$latestVersion = trim($latestVersion->stdout);
+	$latestVersion = trim($latestVersion);
 
 	// If there's no update available or the current version is the latest, throw an exception to skip the test.
 	if (empty($latestVersion) || $currentVersion === $latestVersion) {

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -159,13 +159,11 @@ $steps->Given('/^a misconfigured WP_CONTENT_DIR constant directory$/',
 $steps->Given('/^the current WP version is not the latest$/', function ($world) {
 	// Use wp-cli to get the currently installed WordPress version.
 	$currentVersion = $world->proc('wp core version', [])
-		->run_check()
-		->stdout();
+		->run_check();
 
 	// Use wp-cli to get the latest WordPress version available.
 	$latestVersion = $world->proc('wp core check-update --field=version', [])
-		->run_check()
-		->stdout();
+		->run_check();
 
 	// Normalize versions (remove new lines).
 	$currentVersion = trim($currentVersion);

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -169,6 +169,9 @@ $steps->Given('/^the current WP version is not the latest$/', function ($world) 
 
 	// If there's no update available or the current version is the latest, throw an exception to skip the test.
 	if (empty($latestVersion) || $currentVersion === $latestVersion) {
+		$world->isLatestWPVersion = true;
 		throw new Exception("The current WordPress version is the latest. Test skipped.");
 	}
+
+	$world->isLatestWPVersion = false;
 });

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -158,12 +158,10 @@ $steps->Given('/^a misconfigured WP_CONTENT_DIR constant directory$/',
 
 $steps->Given('/^the current WP version is not the latest$/', function ($world) {
 	// Use wp-cli to get the currently installed WordPress version.
-	$currentVersion = $world->proc('wp core version', [])
-		->run_check();
+	$currentVersion = $world->proc('wp core version');
 
 	// Use wp-cli to get the latest WordPress version available.
-	$latestVersion = $world->proc('wp core check-update --field=version', [])
-		->run_check();
+	$latestVersion = $world->proc('wp core check-update --field=version');
 
 	// Normalize versions (remove new lines).
 	$currentVersion = trim($currentVersion);

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -193,7 +193,7 @@ $steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|
 $steps->Then('/^STDOUT should contain:$/', function ($world, $string) {
 	if (isset($world->isLatestWPVersion) && $world->isLatestWPVersion) {
 		$world->proc('echo "WordPress is the latest version. Skipping"')->run();
-		return
+		return;
 	}
 	// Assuming $world->result->stdout holds the STDOUT from the last command executed
 	$output = $world->result->stdout;

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -17,6 +17,7 @@ $steps->Then( '/^(STDOUT|STDERR) should (be|contain|not contain):$/',
 		// Conditional handling of WP version check.
 		if (isset($world->isLatestWPVersion) && $world->isLatestWPVersion) {
 			checkString( $world->result->$stream, 'WordPress is at the latest version.', $action, $world->result );
+			return;
 		}
 
 		$stream = strtolower( $stream );

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -13,7 +13,6 @@ $steps->Then( '/^the return code should be (\d+)$/',
 
 $steps->Then( '/^(STDOUT|STDERR) should (be|contain|not contain):$/',
 	function ( $world, $stream, $action, PyStringNode $expected ) {
-
 		// Conditional handling of WP version check.
 		if (isset($world->isLatestWPVersion) && $world->isLatestWPVersion) {
 			return;

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -190,3 +190,18 @@ $steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|
 	}
 );
 
+$steps->Then('/^STDOUT should contain:$/', function ($world, $string) {
+	if (isset($world->isLatestWPVersion) && $world->isLatestWPVersion) {
+		$world->proc('echo "WordPress is the latest version. Skipping"')->run();
+		return
+	}
+	// Assuming $world->result->stdout holds the STDOUT from the last command executed
+	$output = $world->result->stdout;
+	$expected = $world->replace_variables((string)$string);
+
+
+	if (strpos($output, $expected) === false) {
+		throw new Exception("Expected text not found in STDOUT");
+	}
+});
+

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -16,7 +16,6 @@ $steps->Then( '/^(STDOUT|STDERR) should (be|contain|not contain):$/',
 
 		// Conditional handling of WP version check.
 		if (isset($world->isLatestWPVersion) && $world->isLatestWPVersion) {
-			checkString( $world->result->$stream, 'WordPress is at the latest version.', $action, $world->result );
 			return;
 		}
 

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -14,6 +14,12 @@ $steps->Then( '/^the return code should be (\d+)$/',
 $steps->Then( '/^(STDOUT|STDERR) should (be|contain|not contain):$/',
 	function ( $world, $stream, $action, PyStringNode $expected ) {
 
+		// Conditional handling of WP version check.
+		if (isset($world->isLatestWPVersion) && $world->isLatestWPVersion) {
+			$world->proc('echo "WordPress is the latest version. Skipping"')->run();
+			return;
+		}
+
 		$stream = strtolower( $stream );
 
 		$expected = $world->replace_variables( (string) $expected );
@@ -189,19 +195,3 @@ $steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|
 		}
 	}
 );
-
-$steps->Then('/^STDOUT should contain:$/', function ($world, $string) {
-	if (isset($world->isLatestWPVersion) && $world->isLatestWPVersion) {
-		$world->proc('echo "WordPress is the latest version. Skipping"')->run();
-		return;
-	}
-	// Assuming $world->result->stdout holds the STDOUT from the last command executed
-	$output = $world->result->stdout;
-	$expected = $world->replace_variables((string)$string);
-
-
-	if (strpos($output, $expected) === false) {
-		throw new Exception("Expected text not found in STDOUT");
-	}
-});
-

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -16,8 +16,7 @@ $steps->Then( '/^(STDOUT|STDERR) should (be|contain|not contain):$/',
 
 		// Conditional handling of WP version check.
 		if (isset($world->isLatestWPVersion) && $world->isLatestWPVersion) {
-			$world->proc('echo "WordPress is the latest version. Skipping"')->run();
-			return;
+			checkString( $world->result->$stream, 'WordPress is at the latest version.', $action, $world->result );
 		}
 
 		$stream = strtolower( $stream );


### PR DESCRIPTION
It's intentional that the version(s) being updated to, 6.5 and 6.4.3, are not the latest version(s) available.