### PR TITLE
Bump WP Core version to 6.4.5

### DIFF
--- a/features/general.feature
+++ b/features/general.feature
@@ -72,7 +72,7 @@ Feature: General tests of WP Launch Check
 
   Scenario: WordPress has a new major version but no new minor version
     Given a WP install
-    And I run `wp core download --version=6.4.4 --force`
+    And I run `wp core download --version=6.4.5 --force`
     And I run `wp theme activate twentytwentytwo`
 
     When I run `wp launchcheck general`


### PR DESCRIPTION
It's intentional that the version(s) being updated to, 6.4.5, are not the latest version(s) available.