### PR TITLE
[SITE-6002] Fix CodeQL alerts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,9 @@ on:
       - master
       - main
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: "Run validation test suite"


### PR DESCRIPTION
## Summary

Adds explicit `permissions: contents: read` to the validate workflow. Without a permissions block, the workflow runs with the default token permissions, which is broader than necessary. This resolves the CodeQL `missing-workflow-permissions` alert.

## Test plan

- [ ] Verify the validate workflow still passes on PRs
- [ ] Confirm CodeQL alert is resolved